### PR TITLE
fixes broken doc url in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ Full featured redis cache backend for Django.
 Documentation
 -------------
 
-http://niwibe.github.io/django-redis/latest/
+http://niwinz.github.io/django-redis/latest/
 
 How to install
 --------------


### PR DESCRIPTION
Maybe you changed your Github username recently, but in doing so you broke the repo's link to the documentation.