### PR TITLE
Add support for alternate serializers to django-redis.

### DIFF
--- a/django_redis/client/herd.py
+++ b/django_redis/client/herd.py
@@ -108,7 +108,7 @@ class HerdClient(DefaultClient):
             if value is None:
                 continue
 
-            val, refresh = self._unpack(self.unpickle(value))
+            val, refresh = self._unpack(self.decode(value))
             recovered_data[map_keys[key]] = None if refresh else val
 
         return recovered_data

--- a/django_redis/client/serializers.py
+++ b/django_redis/client/serializers.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, unicode_literals
+
+# Import the fastest implementation of
+# pickle package. This should be removed
+# when python3 come the unique supported
+# python version
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
+
+import json
+
+try:
+    from django.utils.encoding import smart_bytes
+except ImportError:
+    from django.utils.encoding import smart_str as smart_bytes
+
+from django.core.exceptions import ImproperlyConfigured
+
+
+class BaseSerializer(object):
+    def __init__(self, options):
+        pass
+
+    def dumps(self, value):
+        raise NotImplementedError
+
+    def loads(self, value):
+        raise NotImplementedError
+
+
+class PickleSerializer(BaseSerializer):
+    def __init__(self, options):
+        self._pickle_version = -1
+        self.setup_pickle_version(options)
+
+    def setup_pickle_version(self, options):
+        if "PICKLE_VERSION" in options:
+            try:
+                self._pickle_version = int(self._options["PICKLE_VERSION"])
+            except (ValueError, TypeError):
+                raise ImproperlyConfigured("PICKLE_VERSION value must be an integer")
+
+    def dumps(self, value):
+        return pickle.dumps(value, self._pickle_version)
+
+    def loads(self, value):
+        return pickle.loads(smart_bytes(value))
+
+
+class JSONSerializer(BaseSerializer):
+    def dumps(self, value):
+        return json.dumps(value)
+
+    def loads(self, value):
+        return json.loads(value)

--- a/doc/content.adoc
+++ b/doc/content.adoc
@@ -608,6 +608,32 @@ This client exposes additional settings:
 
 - `CACHE_HERD_TIMEOUT`: Set default herd timeout. (Default value: 60s)
 
+Pluggable serializer
+~~~~~~~~~~~~~~~~~~~~
+
+The pluggable clients serialize data before sending it to the
+server. By default, _django_redis_ serialize the data using Python
+`pickle`. This is very flexible and can handle a large range of object
+types.
+
+To serialize using JSON instead, the serializer `JSONSerializer` is
+also available.
+
+.Example setup
+[source, python]
+----
+ CACHES = {
+    "default": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": "redis://127.0.0.1:6379/1",
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+            "SERIALIZER": "django_redis.client.serializers.JSONSerializer",
+        }
+    }
+}
+----
+
 
 [[license]]
 License

--- a/tests/redis_backend_testapp/tests.py
+++ b/tests/redis_backend_testapp/tests.py
@@ -27,6 +27,8 @@ import django_redis.cache
 from django_redis import pool
 from django_redis.client import herd
 
+from django_redis.client.serializers import JSONSerializer
+
 herd.CACHE_HERD_TIMEOUT = 2
 
 if sys.version_info[0] < 3:
@@ -197,6 +199,9 @@ class DjangoRedisCacheTests(TestCase):
         self.assertEqual(res, "heló")
 
     def test_save_dict(self):
+        if isinstance(self.cache._client._serializer, JSONSerializer):
+            self.skipTest("Datetimes are not JSON serializable")
+
         now_dt = datetime.datetime.now()
         test_dict = {"id":1, "date": now_dt, "name": "Foo"}
 

--- a/tests/runtests-json.py
+++ b/tests/runtests-json.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+
+import os, sys
+sys.path.insert(0, "..")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "test_sqlite_json")
+
+if __name__ == "__main__":
+    from django.core.management import execute_from_command_line
+    args = sys.argv
+    args.insert(1, "test")
+
+    execute_from_command_line(args)

--- a/tests/test_sqlite_json.py
+++ b/tests/test_sqlite_json.py
@@ -1,0 +1,48 @@
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3"
+    },
+}
+
+SECRET_KEY = "django_tests_secret_key"
+TIME_ZONE = "America/Chicago"
+LANGUAGE_CODE = "en-us"
+ADMIN_MEDIA_PREFIX = "/static/admin/"
+STATICFILES_DIRS = ()
+
+MIDDLEWARE_CLASSES = []
+
+CACHES = {
+    "default": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": [
+            "redis://127.0.0.1:6379?db=1",
+            "redis://127.0.0.1:6379?db=1",
+        ],
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+            "SERIALIZER": "django_redis.client.serializers.JSONSerializer",
+        }
+    },
+    "doesnotexist": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": "127.0.0.1:56379:1",
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+            "SERIALIZER": "django_redis.client.serializers.JSONSerializer",
+        }
+    },
+    "sample": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": "127.0.0.1:6379:1,127.0.0.1:6379:1",
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+            "SERIALIZER": "django_redis.client.serializers.JSONSerializer",
+        }
+    },
+}
+
+INSTALLED_APPS = (
+    "redis_backend_testapp",
+    "hashring_test",
+)


### PR DESCRIPTION
Python pickle remains the default serializer. Added a second
serializer, JSONSerializer.

Fixes #133 

All feedback welcome. Thanks.