### PR TITLE
Fixing JSONSerializer.loads()

### DIFF
--- a/django_redis/client/serializers.py
+++ b/django_redis/client/serializers.py
@@ -56,4 +56,8 @@ class JSONSerializer(BaseSerializer):
         return json.dumps(value)
 
     def loads(self, value):
-        return json.loads(value)
+        try:
+            return json.loads(value)
+        except TypeError:
+            # pickle.loads() accepts bytes, but json.loads() accepts string
+            return json.loads(value.decode())


### PR DESCRIPTION
In Python3, redis returns value of key as bytes. That's good if we are using PickleSerializer, but if we use JSONSerializer, we'll get TypeError, as json.loads() accepts string, not bytes.
This code fixes this bug.
This is my very first contribution, so please tell me if I did something wrong.