### PR TITLE
Fixing JSONSerializer.loads()

### DIFF
--- a/django_redis/client/serializers.py
+++ b/django_redis/client/serializers.py
@@ -56,4 +56,4 @@ class JSONSerializer(BaseSerializer):
         return json.dumps(value)
 
     def loads(self, value):
-        return json.loads(value)
+        return json.loads(value.decode())


### PR DESCRIPTION
In Python3, redis returns value of the key as bytes. That's good if we are using PickleSerializer, but if we use JSONSerializer, we'll get TypeError, as json.loads() accepts string, not bytes. 
When we use cache as a session backend, this error may be hided.
This means, for example, that you will not be able to login to your Django app, but you will see no errors (this happened in my project).