### PR TITLE
Add support for msgpack serializer to django-redis

### DIFF
--- a/django_redis/client/serializers.py
+++ b/django_redis/client/serializers.py
@@ -13,6 +13,9 @@ except ImportError:
 
 import json
 
+#Use msgpack from http://msgpack.org/
+import msgpack
+
 try:
     from django.utils.encoding import smart_bytes
 except ImportError:
@@ -57,3 +60,11 @@ class JSONSerializer(BaseSerializer):
 
     def loads(self, value):
         return json.loads(value)
+
+
+class MSGPackSerializer(BaseSerializer):
+    def dumps(self, value):
+        return msgpack.dumps(value)
+
+    def loads(self, value):
+        return msgpack.loads(value, encoding='utf-8)

--- a/doc/content.adoc
+++ b/doc/content.adoc
@@ -634,7 +634,24 @@ also available.
 }
 ----
 
+There's also support for serialization using 'MsgPack' 'http://msgpack.org/'
+It requires the msgpack-python library
 
+.Example setup
+[source, python]
+----
+ CACHES = {
+    "default": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": "redis://127.0.0.1:6379/1",
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+            "SERIALIZER": "django_redis.client.serializers.MSGPackSerializer",
+        }
+    }
+}
+
+----
 [[license]]
 License
 -------

--- a/tests/redis_backend_testapp/tests.py
+++ b/tests/redis_backend_testapp/tests.py
@@ -27,7 +27,7 @@ import django_redis.cache
 from django_redis import pool
 from django_redis.client import herd
 
-from django_redis.client.serializers import JSONSerializer
+from django_redis.client.serializers import JSONSerializer, MSGPackSerializer
 
 herd.CACHE_HERD_TIMEOUT = 2
 
@@ -182,6 +182,7 @@ class DjangoRedisCacheTests(TestCase):
         self.cache.set("test_key", "hello")
         res = self.cache.get("test_key")
 
+        type(res)
         self.assertIsInstance(res, text_type)
         self.assertEqual(res, "hello")
 
@@ -202,7 +203,13 @@ class DjangoRedisCacheTests(TestCase):
         if isinstance(self.cache._client._serializer, JSONSerializer):
             self.skipTest("Datetimes are not JSON serializable")
 
-        now_dt = datetime.datetime.now()
+        if isinstance(self.cache._client._serializer, MSGPackSerializer):
+            #MSGPackSerializer serializers use the isoformat for datetimes
+            #https://github.com/msgpack/msgpack-python/issues/12
+            now_dt = datetime.datetime.now().isoformat()
+        else:
+            now_dt = datetime.datetime.now()
+
         test_dict = {"id":1, "date": now_dt, "name": "Foo"}
 
         self.cache.set("test_key", test_dict)

--- a/tests/runtests-msgpack.py
+++ b/tests/runtests-msgpack.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+
+import os, sys
+sys.path.insert(0, "..")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "test_sqlite_msgpack")
+
+if __name__ == "__main__":
+    from django.core.management import execute_from_command_line
+    args = sys.argv
+    args.insert(1, "test")
+
+    execute_from_command_line(args)

--- a/tests/test_sqlite_msgpack.py
+++ b/tests/test_sqlite_msgpack.py
@@ -1,0 +1,48 @@
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3"
+    },
+}
+
+SECRET_KEY = "django_tests_secret_key"
+TIME_ZONE = "America/Chicago"
+LANGUAGE_CODE = "en-us"
+ADMIN_MEDIA_PREFIX = "/static/admin/"
+STATICFILES_DIRS = ()
+
+MIDDLEWARE_CLASSES = []
+
+CACHES = {
+    "default": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": [
+            "redis://127.0.0.1:6379?db=1",
+            "redis://127.0.0.1:6379?db=1",
+        ],
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+            "SERIALIZER": "django_redis.client.serializers.MSGPackSerializer",
+        }
+    },
+    "doesnotexist": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": "127.0.0.1:56379:1",
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+            "SERIALIZER": "django_redis.client.serializers.MSGPackSerializer",
+        }
+    },
+    "sample": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": "127.0.0.1:6379:1,127.0.0.1:6379:1",
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+            "SERIALIZER": "django_redis.client.serializers.MSGPackSerializer",
+        }
+    },
+}
+
+INSTALLED_APPS = (
+    "redis_backend_testapp",
+    "hashring_test",
+)


### PR DESCRIPTION
After the initial support for Serialization, here's serialization using msgpack. Added a third serializer, MSGPackSerializer