### PR TITLE
Added serializers to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
     packages = [
         "django_redis",
         "django_redis.client",
+        "django_redis.serializers"
     ],
     description = description.strip(),
     install_requires=[


### PR DESCRIPTION
This was causing the installation to not work correctly, as it never installed the serializers folder.