### PR TITLE
Return empty dict from get_many()

### DIFF
--- a/tests/redis_backend_testapp/tests.py
+++ b/tests/redis_backend_testapp/tests.py
@@ -547,9 +547,15 @@ class DjangoOmitExceptionsTests(TestCase):
         self._orig_setting = django_redis.cache.DJANGO_REDIS_IGNORE_EXCEPTIONS
         django_redis.cache.DJANGO_REDIS_IGNORE_EXCEPTIONS = True
         self.cache = get_cache("doesnotexist")
+        self.cache._orig_ignore_exceptions = self.cache._ignore_exceptions
+        self.cache._ignore_exceptions = True
 
     def tearDown(self):
         django_redis.cache.DJANGO_REDIS_IGNORE_EXCEPTIONS = self._orig_setting
+        self.cache._ignore_exceptions = self.cache._orig_ignore_exceptions
+
+    def test_get_many_returns_default_arg(self):
+        self.assertEqual(self.cache.get_many(["key1", "key2", "key3"]), {})
 
     def test_get(self):
         self.assertIsNone(self.cache.get("key"))


### PR DESCRIPTION
Fix for #149 

- Return an empty dict from django_redis.cache.RedisCache.get_many() when
  IGNORE_EXCEPTIONS is True.
- Convert omit_exception decorator to a callable. Pass it a return_value
  keyword argument to specify a default return value when
  IGNORE_EXCEPTIONS is True.