### PR TITLE
Allow user to log/set logger for Ignored Exceptions

### DIFF
--- a/django_redis/cache.py
+++ b/django_redis/cache.py
@@ -1,5 +1,6 @@
 import functools
 import warnings
+import logging
 
 from django.conf import settings
 from django.core.cache.backends.base import BaseCache
@@ -7,8 +8,12 @@ from django.core.cache.backends.base import BaseCache
 from .util import load_class
 from .exceptions import ConnectionInterrupted
 
-
 DJANGO_REDIS_IGNORE_EXCEPTIONS = getattr(settings, "DJANGO_REDIS_IGNORE_EXCEPTIONS", False)
+DJANGO_REDIS_LOG_IGNORED_EXCEPTIONS = getattr(settings, "DJANGO_REDIS_LOG_IGNORED_EXCEPTIONS", False)
+DJANGO_REDIS_LOGGER = getattr(settings, "DJANGO_REDIS_LOGGER", False)
+
+if DJANGO_REDIS_LOG_IGNORED_EXCEPTIONS:
+    logger = logging.getLogger((DJANGO_REDIS_LOGGER or __name__))
 
 
 def omit_exception(method):
@@ -25,7 +30,12 @@ def omit_exception(method):
             return method(self, *args, **kwargs)
         except ConnectionInterrupted as e:
             if self._ignore_exceptions:
-                return None
+
+                if DJANGO_REDIS_LOG_IGNORED_EXCEPTIONS:
+                    logger.error(str(e))
+
+                #return default or None
+                return kwargs.get('default', None)
 
             raise e.parent
 
@@ -68,13 +78,8 @@ class RedisCache(BaseCache):
 
     @omit_exception
     def get(self, key, default=None, version=None, client=None):
-        try:
-            return self.client.get(key, default=default, version=version,
-                                   client=client)
-        except ConnectionInterrupted:
-            if DJANGO_REDIS_IGNORE_EXCEPTIONS:
-                return default
-            raise
+        return self.client.get(key, default=default, version=version,
+                               client=client)
 
     @omit_exception
     def delete(self, *args, **kwargs):

--- a/django_redis/exceptions.py
+++ b/django_redis/exceptions.py
@@ -9,4 +9,5 @@ class ConnectionInterrumped(Exception):
 
 
 class ConnectionInterrupted(ConnectionInterrumped):
-    pass
+    def __str__(self):
+      return "ConnectionInterrupted: Connection to redis server failed"

--- a/doc/content.adoc
+++ b/doc/content.adoc
@@ -267,6 +267,29 @@ your settings:
 DJANGO_REDIS_IGNORE_EXCEPTIONS = True
 ----
 
+
+Log Ignored Exceptions
+~~~~~~~~~~~~~~~~~~~~~~
+
+When ignoring exceptions with `IGNORE_EXCEPTIONS` or `DJANGO_REDIS_IGNORE_EXCEPTIONS`,
+you may optionally log exceptions using the global variable `DJANGO_REDIS_LOG_IGNORED_EXCEPTIONS`
+in your settings file.
+
+[source, python]
+----
+DJANGO_REDIS_LOG_IGNORED_EXCEPTIONS = True
+----
+
+If you wish to specify the logger in which the exceptions are output, simply set the global
+variable `DJANGO_REDIS_LOGGER` to the string name and/or path of the desired logger. This will
+default to `__name__` if no logger is specified and `DJANGO_REDIS_LOG_IGNORED_EXCEPTIONS` is `True`
+
+[source, python]
+----
+DJANGO_REDIS_IGNORE_EXCEPTIONS = 'some.specified.logger'
+----
+
+
 Infinite timeout
 ~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Proposed change is to allow users to log ignored exceptions so they are not failing silently. This has proven to be very useful in production. User would set the following global variables in their `settings.py` file:

`DJANGO_REDIS_LOG_IGNORED_EXCEPTIONS` - boolean (defaults to `False`)
`DJANGO_REDIS_LOGGER` - string name/path for logger (defaults to `__name__`)

Let me know your thoughts, and if you think it looks good, I'd be more than happy to add docs.