### PR TITLE
cache.get doesn't obey ignore exceptions

### DIFF
--- a/django_redis/cache.py
+++ b/django_redis/cache.py
@@ -72,7 +72,7 @@ class RedisCache(BaseCache):
             return self.client.get(key, default=default, version=version,
                                    client=client)
         except ConnectionInterrupted:
-            if DJANGO_REDIS_IGNORE_EXCEPTIONS:
+            if self._ignore_exceptions:
                 return default
             raise
 


### PR DESCRIPTION
if the particular instance of the backend is configured to ignore exceptions but the global setting isn't, that instance should still ignore exception