### PR TITLE
Fix delete_many for empty generators

### DIFF
--- a/django_redis/client/default.py
+++ b/django_redis/client/default.py
@@ -269,10 +269,11 @@ class DefaultClient(object):
         if client is None:
             client = self.get_client(write=True)
 
+        keys = [self.make_key(k, version=version) for k in keys]
+
         if not keys:
             return
 
-        keys = [self.make_key(k, version=version) for k in keys]
         try:
             return client.delete(*keys)
         except _main_exceptions as e:

--- a/tests/redis_backend_testapp/tests.py
+++ b/tests/redis_backend_testapp/tests.py
@@ -327,6 +327,21 @@ class DjangoRedisCacheTests(TestCase):
         res = self.cache.delete_many(["a","b"])
         self.assertFalse(bool(res))
 
+    def test_delete_many_generator(self):
+        self.cache.set_many({"a": 1, "b": 2, "c": 3})
+        res = self.cache.delete_many(key for key in ["a","b"])
+        self.assertTrue(bool(res))
+
+        res = self.cache.get_many(["a", "b", "c"])
+        self.assertEqual(res, {"c": 3})
+
+        res = self.cache.delete_many(["a","b"])
+        self.assertFalse(bool(res))
+
+    def test_delete_many_empty_generator(self):
+        res = self.cache.delete_many(key for key in [])
+        self.assertFalse(bool(res))
+
     def test_incr(self):
         try:
             self.cache.set("num", 1)


### PR DESCRIPTION
When delete_many is called with a generator instead of a list, then ```bool(keys)``` is always true, even when the generator is "empty".

But the line ```keys = [self.make_key(k, version=version) for k in keys]``` converts the generator into a list so ```bool(keys)``` does work again after the line.