### PR TITLE
Fix cache.clear() to respect KEY_PREFIX

### DIFF
--- a/django_redis/client/default.py
+++ b/django_redis/client/default.py
@@ -283,10 +283,7 @@ class DefaultClient(object):
         """
         Flush all cache keys.
         """
-        if client is None:
-            client = self.get_client(write=True)
-
-        client.flushdb()
+        self.delete_pattern("*", client=client)
 
     def decode(self, value):
         """

--- a/django_redis/client/sharded.py
+++ b/django_redis/client/sharded.py
@@ -242,7 +242,7 @@ class ShardClient(DefaultClient):
         decoded_keys = (smart_text(k) for k in keys)
         return [self.reverse_key(k) for k in decoded_keys]
 
-    def delete_pattern(self, pattern, version=None):
+    def delete_pattern(self, pattern, version=None, client=None):
         """
         Remove all keys matching pattern.
         """

--- a/tests/redis_backend_testapp/tests.py
+++ b/tests/redis_backend_testapp/tests.py
@@ -553,6 +553,21 @@ class DjangoRedisCacheTests(TestCase):
         except NotImplementedError:
             pass
 
+    def test_clear_with_cache_prefix(self):
+        """
+        Tests that cache.clear() does only delete keys which starts with the
+        correct prefix configured with KEY_PREFIX.
+        """
+        cache_normal = get_cache('sample')
+        cache_with_prefix = get_cache('with_prefix')
+        cache_normal.set('some_key', 'some_value')
+        cache_with_prefix.set('other_key', 'other_value')
+
+        cache_with_prefix.clear()
+
+        self.assertIsNone(cache_with_prefix.get('other_key'))
+        self.assertEqual(cache_normal.get('some_key'), 'some_value')
+
 
 import django_redis.cache
 

--- a/tests/test_sqlite.py
+++ b/tests/test_sqlite.py
@@ -37,6 +37,14 @@ CACHES = {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
         }
     },
+    "with_prefix": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": "127.0.0.1:6379:1",
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+        },
+        "KEY_PREFIX": "test-prefix",
+    },
 }
 
 INSTALLED_APPS = (

--- a/tests/test_sqlite_herd.py
+++ b/tests/test_sqlite_herd.py
@@ -50,6 +50,14 @@ CACHES = {
             'CLIENT_CLASS': 'django_redis.client.HerdClient',
         }
     },
+    "with_prefix": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": "127.0.0.1:6379:1",
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.HerdClient",
+        },
+        "KEY_PREFIX": "test-prefix",
+    },
 }
 
 # TEST_RUNNER = 'django.test.simple.DjangoTestSuiteRunner'

--- a/tests/test_sqlite_json.py
+++ b/tests/test_sqlite_json.py
@@ -40,6 +40,15 @@ CACHES = {
             "SERIALIZER": "django_redis.serializers.json.JSONSerializer",
         }
     },
+    "with_prefix": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": "127.0.0.1:6379:1",
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+            "SERIALIZER": "django_redis.serializers.json.JSONSerializer",
+        },
+        "KEY_PREFIX": "test-prefix",
+    },
 }
 
 INSTALLED_APPS = (

--- a/tests/test_sqlite_msgpack.py
+++ b/tests/test_sqlite_msgpack.py
@@ -40,6 +40,15 @@ CACHES = {
             "SERIALIZER": "django_redis.serializers.msgpack.MSGPackSerializer",
         }
     },
+    "with_prefix": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": "127.0.0.1:6379:1",
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+            "SERIALIZER": "django_redis.serializers.msgpack.MSGPackSerializer",
+        },
+        "KEY_PREFIX": "test-prefix",
+    },
 }
 
 INSTALLED_APPS = (

--- a/tests/test_sqlite_sharding.py
+++ b/tests/test_sqlite_sharding.py
@@ -55,6 +55,14 @@ CACHES = {
             'CLIENT_CLASS': 'django_redis.client.ShardClient',
         }
     },
+    "with_prefix": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": "127.0.0.1:6379:1",
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.ShardClient",
+        },
+        "KEY_PREFIX": "test-prefix",
+    },
 }
 
 if django.VERSION[1] >= 8:

--- a/tests/test_sqlite_usock.py
+++ b/tests/test_sqlite_usock.py
@@ -50,6 +50,14 @@ CACHES = {
             'CLIENT_CLASS': 'redis_cache.client.DefaultClient',
         }
     },
+    "with_prefix": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": "127.0.0.1:6379:1",
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+        },
+        "KEY_PREFIX": "test-prefix",
+    },
 }
 
 TEST_RUNNER = 'django.test.simple.DjangoTestSuiteRunner'


### PR DESCRIPTION
Before this commit cache.clear() called flushdb which deletes all keys.

Fixes #168