### PR TITLE
Include documentation and tests in source tarball.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,5 @@
-include LICENSE AUTHORS.rst README.rst
+include LICENSE
+include AUTHORS.rst
+include README.rst
+recursive-include tests README.txt *.py
+recursive-include doc Makefile *.adoc *.html


### PR DESCRIPTION
This allows distribution packages (e.g. Debian) to run the tests and build the
documentation from source with only the pypi source tarball.