### PR TITLE
django-redis can now be installed straight from GitHub

### DIFF
--- a/django_redis/__init__.py
+++ b/django_redis/__init__.py
@@ -1,15 +1,5 @@
 # -*- coding: utf-8 -*-
 
-try:
-    from django.core.cache import caches
-except ImportError:
-    # Django <1.7
-    from django.core.cache import get_cache
-else:
-    def get_cache(alias):
-        return caches[alias]
-
-
 VERSION = (4, 3, 0)
 __version__ = '.'.join(map(str, VERSION))
 
@@ -18,6 +8,15 @@ def get_redis_connection(alias='default', write=True):
     """
     Helper used for obtain a raw redis client.
     """
+
+    try:
+        from django.core.cache import caches
+    except ImportError:
+        # Django <1.7
+        from django.core.cache import get_cache
+    else:
+        def get_cache(alias):
+            return caches[alias]
 
     cache = get_cache(alias)
     if not hasattr(cache.client, 'get_client'):


### PR DESCRIPTION
Since there haven't been any releases in the last couple of months, and I needed some great new features of this library, I wanted to pull it into my virtualenv straight from GitHub (`-e git+https://github.com/niwinz/django-redis.git@master#egg=django-redis`), but it failed to install into a brand new virtualenv because when installing it at the same time with Django (e.g. bootstrapping from a `requirements.txt` file), the setup script cannot determine the version, because `django.core.cache` is not available yet.

This change should fix that problem.

Looking forward to a proper release soon, thanks for all your work! :)

The error for reference:

```
Obtaining django-redis from git+https://github.com/niwinz/django-redis.git@master#egg=django-redis (from -r /app-env/requirements.txt (line 77))
  Cloning https://github.com/niwinz/django-redis.git (to master) to /src/django-redis
  Running setup.py (path:/src/django-redis/setup.py) egg_info for package django-redis
    Traceback (most recent call last):
      File "<string>", line 17, in <module>
      File "/src/django-redis/setup.py", line 3, in <module>
        from django_redis import __version__
      File "django_redis/__init__.py", line 7, in <module>
        from django.core.cache import get_cache
    ImportError: No module named django.core.cache
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):

  File "<string>", line 17, in <module>

  File "/src/django-redis/setup.py", line 3, in <module>

    from django_redis import __version__

  File "django_redis/__init__.py", line 7, in <module>

    from django.core.cache import get_cache

ImportError: No module named django.core.cache
```