### PR TITLE
Fix timeout bug.

### DIFF
--- a/django_redis/client/default.py
+++ b/django_redis/client/default.py
@@ -129,7 +129,10 @@ class DefaultClient(object):
         try:
             if timeout is not None:
                 if timeout > 0:
-                    timeout = int(timeout)
+                    # If "timeout" is 0.1, this would make it 0, which redis
+                    # considers as "don't expire". Instead, set it to a minimum
+                    # of 1.
+                    timeout = max(1, int(timeout))
                 elif timeout <= 0:
                     if nx:
                         # Using negative timeouts when nx is True should


### PR DESCRIPTION
When passing a float between 0 and 1 as the timeout (e.g. 0.5), the code would execute `int(timeout)`, which returns 0, and would never expire the key. My change sets a positive timeout to a minimum of 1.

`math.ceil(timeout)` is another course of action, but I decided not to change the current semantics too much.

If this could be changed and released as a bugfix ASAP, I would be grateful, as it is impacting production very much for us.