### PR TITLE
Added Django 1.10 to tox testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ python:
   - "2.7"
 
 env:
-  - DJANGO="django==1.10rc1"
-  - DJANGO="django==1.9.8"
+  - DJANGO="django==1.10"
+  - DJANGO="django==1.9.9"
   - DJANGO="django==1.8.14"
   - DJANGO="django==1.7.11"
   - DJANGO="django==1.6.11"

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
-envlist = {py27,pypy}-django{14,15,16,17,18,19},
-          {py33,py34,pypy3}-django{15,16,17,18,19}
+envlist = {py27,pypy}-django{14,15,16,17,18,19,110},
+          {py33,py34,pypy3}-django{15,16,17,18,19,110}
 
 [testenv]
 commands =
@@ -14,7 +14,8 @@ deps =
     django16: Django>=1.6, <1.7
     django17: Django>=1.7, <1.8
     django18: Django==1.8.14
-    django19: Django==1.9.8
+    django19: Django==1.9.9
+    django110: Django==1.10
     mock==2.0.0
     redis==2.10.5
     msgpack-python>=0.4.6


### PR DESCRIPTION
Django 1.10 was officially released on August 1st, 2016. Adding in testing for support of Django 1.10. Also updated Django 1.9 to latest release.