### PR TITLE
Allow to write to slave, if master is down

### DIFF
--- a/django_redis/client/default.py
+++ b/django_redis/client/default.py
@@ -80,7 +80,7 @@ class DefaultClient(object):
 
         return random.randint(1, len(self._server) - 1)
 
-    def get_client(self, write=True, tried=[]):
+    def get_client(self, write=True, tried=[], show_index=False):
         """
         Method used for obtain a raw redis client.
 
@@ -93,7 +93,10 @@ class DefaultClient(object):
         if self._clients[index] is None:
             self._clients[index] = self.connect(index)
 
-        return self._clients[index], index
+        if show_index:
+            return self._clients[index], index
+        else:
+            return self._clients[index]
 
     def connect(self, index=0):
         """
@@ -123,7 +126,7 @@ class DefaultClient(object):
         while True:
             try:
                 if not client:
-                    client, index = self.get_client(write=True, tried=tried)
+                    client, index = self.get_client(write=True, tried=tried, show_index=True)
 
                 if timeout is not None:
                     if timeout > 0:
@@ -156,7 +159,7 @@ class DefaultClient(object):
         """
 
         if client is None:
-            client, index = self.get_client(write=True)
+            client = self.get_client(write=True)
 
         if version is None:
             version = self._backend.version
@@ -196,7 +199,7 @@ class DefaultClient(object):
         Returns decoded value if key is found, the default if not.
         """
         if client is None:
-            client, index = self.get_client(write=False)
+            client = self.get_client(write=False)
 
         key = self.make_key(key, version=version)
 
@@ -212,7 +215,7 @@ class DefaultClient(object):
 
     def persist(self, key, version=None, client=None):
         if client is None:
-            client, index = self.get_client(write=True)
+            client = self.get_client(write=True)
 
         key = self.make_key(key, version=version)
 
@@ -221,7 +224,7 @@ class DefaultClient(object):
 
     def expire(self, key, timeout, version=None, client=None):
         if client is None:
-            client, index = self.get_client(write=True)
+            client = self.get_client(write=True)
 
         key = self.make_key(key, version=version)
 
@@ -231,7 +234,7 @@ class DefaultClient(object):
     def lock(self, key, version=None, timeout=None, sleep=0.1,
              blocking_timeout=None, client=None):
         if client is None:
-            client, index = self.get_client(write=True)
+            client = self.get_client(write=True)
 
         key = self.make_key(key, version=version)
         return client.lock(key, timeout=timeout, sleep=sleep,
@@ -242,7 +245,7 @@ class DefaultClient(object):
         Remove a key from the cache.
         """
         if client is None:
-            client, index = self.get_client(write=True)
+            client = self.get_client(write=True)
 
         try:
             return client.delete(self.make_key(key, version=version,
@@ -256,7 +259,7 @@ class DefaultClient(object):
         """
 
         if client is None:
-            client, index = self.get_client(write=True)
+            client = self.get_client(write=True)
 
         pattern = self.make_key(pattern, version=version, prefix=prefix)
         try:
@@ -274,7 +277,7 @@ class DefaultClient(object):
         """
 
         if client is None:
-            client, index = self.get_client(write=True)
+            client = self.get_client(write=True)
 
         keys = [self.make_key(k, version=version) for k in keys]
 
@@ -292,7 +295,7 @@ class DefaultClient(object):
         """
 
         if client is None:
-            client, index = self.get_client(write=True)
+            client = self.get_client(write=True)
 
         try:
             count = 0
@@ -336,7 +339,7 @@ class DefaultClient(object):
         """
 
         if client is None:
-            client, index = self.get_client(write=False)
+            client = self.get_client(write=False)
 
         if not keys:
             return {}
@@ -366,7 +369,7 @@ class DefaultClient(object):
         the default cache timeout will be used.
         """
         if client is None:
-            client, index = self.get_client(write=True)
+            client = self.get_client(write=True)
 
         try:
             pipeline = client.pipeline()
@@ -378,7 +381,7 @@ class DefaultClient(object):
 
     def _incr(self, key, delta=1, version=None, client=None):
         if client is None:
-            client, index = self.get_client(write=True)
+            client = self.get_client(write=True)
 
         key = self.make_key(key, version=version)
 
@@ -438,7 +441,7 @@ class DefaultClient(object):
         If key is a non volatile key, it returns None.
         """
         if client is None:
-            client, index = self.get_client(write=False)
+            client = self.get_client(write=False)
 
         key = self.make_key(key, version=version)
         if not client.exists(key):
@@ -462,7 +465,7 @@ class DefaultClient(object):
         """
 
         if client is None:
-            client, index = self.get_client(write=False)
+            client = self.get_client(write=False)
 
         key = self.make_key(key, version=version)
         try:
@@ -477,7 +480,7 @@ class DefaultClient(object):
         """
 
         if client is None:
-            client, index = self.get_client(write=False)
+            client = self.get_client(write=False)
 
         pattern = self.make_key(search, version=version)
         for item in client.scan_iter(match=pattern, count=itersize):
@@ -493,7 +496,7 @@ class DefaultClient(object):
         """
 
         if client is None:
-            client, index = self.get_client(write=False)
+            client = self.get_client(write=False)
 
         pattern = self.make_key(search, version=version)
         try:

--- a/django_redis/client/default.py
+++ b/django_redis/client/default.py
@@ -61,7 +61,7 @@ class DefaultClient(object):
     def __contains__(self, key):
         return self.has_key(key)
 
-    def get_next_client_index(self, write=True):
+    def get_next_client_index(self, write=True, tried=[]):
         """
         Return a next index for read client.
         This function implements a default behavior for
@@ -70,6 +70,10 @@ class DefaultClient(object):
         Overwrite this function if you want a specific
         behavior.
         """
+        if tried and len(tried) < len(self._server):
+            not_tried = [i for i in range(0, len(self._server)) if i not in tried]
+            return random.choice(not_tried)
+
         if write or len(self._server) == 1:
             return 0
 

--- a/django_redis/client/default.py
+++ b/django_redis/client/default.py
@@ -46,6 +46,7 @@ class DefaultClient(object):
 
         self._clients = [None] * len(self._server)
         self._options = params.get("OPTIONS", {})
+        self._slave_read_only = self._options.get('SLAVE_READ_ONLY', True)
 
         serializer_path = self._options.get("SERIALIZER", "django_redis.serializers.pickle.PickleSerializer")
         serializer_cls = load_class(serializer_path)
@@ -142,7 +143,7 @@ class DefaultClient(object):
 
                 return client.set(nkey, nvalue, nx=nx, px=timeout, xx=xx)
             except _main_exceptions as e:
-                if not original_client and len(tried) < len(self._server):
+                if not original_client and not self._slave_read_only and len(tried) < len(self._server):
                     tried.append(index)
                     client = None
                     continue

--- a/django_redis/client/default.py
+++ b/django_redis/client/default.py
@@ -62,7 +62,7 @@ class DefaultClient(object):
     def __contains__(self, key):
         return self.has_key(key)
 
-    def get_next_client_index(self, write=True, tried=[]):
+    def get_next_client_index(self, write=True, tried=()):
         """
         Return a next index for read client.
         This function implements a default behavior for
@@ -80,7 +80,7 @@ class DefaultClient(object):
 
         return random.randint(1, len(self._server) - 1)
 
-    def get_client(self, write=True, tried=[], show_index=False):
+    def get_client(self, write=True, tried=(), show_index=False):
         """
         Method used for obtain a raw redis client.
 
@@ -88,7 +88,7 @@ class DefaultClient(object):
         operations for obtain a native redis client/connection
         instance.
         """
-        index = self.get_next_client_index(write=write, tried=tried)
+        index = self.get_next_client_index(write=write, tried=tried or [])
 
         if self._clients[index] is None:
             self._clients[index] = self.connect(index)


### PR DESCRIPTION
Activated only if ``OPTIONS['SLAVE_READ_ONLY']=False``.

Double-negative names are not nice, but made this way to keep the same as the Redis config option.

Implemented only on Default client and SET operation.