### PR TITLE
Use a requirements.txt to install test dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,7 @@ env:
 
 install:
   - pip install $DJANGO
-  - pip install mock
-  - pip install msgpack-python>=0.4.6
-  - pip install redis>=2.10.0
-  - pip install fakeredis
+  - pip install -r requirements.txt
 
 script:
   - (cd tests && python runtests.py)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+DJANGO>=1.8
+fakeredis
+mock
+msgpack-python>=0.4.6
+redis>=2.10.0

--- a/tests/README.txt
+++ b/tests/README.txt
@@ -1,15 +1,12 @@
 Test requirements
 -----------------
 
-python packages
+Python packages
 ~~~~~~~~~~~~~~~
 
-the following packages can be installed with pip
+Install the development requirements using the requirements.txt file:
 
-* redis (https://github.com/andymccurdy/redis-py)
-* hiredis (https://github.com/redis/hiredis)
-* django (https://www.djangoproject.com/)
-* msgpack-python (http://msgpack.org/)
+    pip install -r requirements.txt
 
 redis
 ~~~~~


### PR DESCRIPTION
Simplifies development environment setup and centralizes project requirements
to one spot.