### PR TITLE
Drop deprecated exception with typo ConnectionInterrumped

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,14 @@ Changelog
 Version 4.7.0
 -------------
 
+Date: UNRELEASED
+
+- Drop deprecated exception with typo ConnectionInterrumped. Use
+  ConnectionInterrupted instead.
+
+Version 4.7.0
+-------------
+
 Date: 2017-01-02
 
 - Add the ability to enable write to slave when master is not available.

--- a/django_redis/exceptions.py
+++ b/django_redis/exceptions.py
@@ -1,13 +1,11 @@
 # -*- coding: utf-8 -*-
 
-class ConnectionInterrumped(Exception):
-    """Deprecated exception name with a typo."""
+
+class ConnectionInterrupted(Exception):
     def __init__(self, connection, parent=None):
         self.connection = connection
         self.parent = parent
 
-
-class ConnectionInterrupted(ConnectionInterrumped):
     def __str__(self):
       error_type = "ConnectionInterrupted"
       error_msg = "An error occurred while connecting to redis"


### PR DESCRIPTION
Code should use ConnectionInterrupted instead. ConnectionInterrupted has been
available since version 3.4.0 released 2013-12-15. Enough time for code to have
been adjusted.