### PR TITLE
Remove workaround for older versions of redis-py

### DIFF
--- a/django_redis/client/default.py
+++ b/django_redis/client/default.py
@@ -12,20 +12,14 @@ from django.core.cache.backends.base import DEFAULT_TIMEOUT, get_key_func
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.encoding import smart_text
 
-from redis.exceptions import ConnectionError
-from redis.exceptions import ResponseError
-
-# Compatibility with redis-py 2.10.x+
-
-try:
-    from redis.exceptions import TimeoutError, ResponseError
-    _main_exceptions = (TimeoutError, ResponseError, ConnectionError, socket.timeout)
-except ImportError:
-    _main_exceptions = (ConnectionError, socket.timeout)
+from redis.exceptions import ConnectionError, ResponseError, TimeoutError
 
 from ..util import CacheKey, load_class, integer_types
 from ..exceptions import ConnectionInterrupted, CompressorError
 from .. import pool
+
+
+_main_exceptions = (TimeoutError, ResponseError, ConnectionError, socket.timeout)
 
 
 class DefaultClient(object):

--- a/django_redis/client/herd.py
+++ b/django_redis/client/herd.py
@@ -5,23 +5,15 @@ import socket
 import time
 from collections import OrderedDict
 
-from redis.exceptions import ConnectionError
+from redis.exceptions import ConnectionError, ResponseError, TimeoutError
 
 from django.conf import settings
 
 from .default import DEFAULT_TIMEOUT, DefaultClient
 from ..exceptions import ConnectionInterrupted
 
-from redis.exceptions import ConnectionError
-from redis.exceptions import ResponseError
 
-# Compatibility with redis-py 2.10.x+
-
-try:
-    from redis.exceptions import TimeoutError, ResponseError
-    _main_exceptions = (TimeoutError, ResponseError, ConnectionError, socket.timeout)
-except ImportError:
-    _main_exceptions = (ConnectionError, socket.timeout)
+_main_exceptions = (ConnectionError, ResponseError, TimeoutError, socket.timeout)
 
 
 class Marker(object):


### PR DESCRIPTION
As the project requires redis-py>=2.10.0, can assume the TimeoutError exception
exists.