### PR TITLE
'DefaultClient' object has no attribute 'client'

### DIFF
--- a/django_redis/client/default.py
+++ b/django_redis/client/default.py
@@ -518,6 +518,7 @@ class DefaultClient(object):
 
     def close(self, **kwargs):
         if getattr(settings, "DJANGO_REDIS_CLOSE_CONNECTION", False):
-            for c in self.client.connection_pool._available_connections:
-                c.disconnect()
-            del self._client
+            for i in range(len(self._clients)):
+                for c in self._clients[i].connection_pool._available_connections:
+                    c.disconnect()
+                self._clients[i] = None


### PR DESCRIPTION
```
 django_redis.__version__
'4.6.0'
```

when set `DJANGO_REDIS_CLOSE_CONNECTION = True`, `DefaultClient.close` called and this raise:
```
Traceback (most recent call last):
  File "/usr/lib/python2.7/wsgiref/handlers.py", line 86, in run
    self.finish_response()
  File "/usr/lib/python2.7/wsgiref/handlers.py", line 131, in finish_response
    self.close()
  File "/usr/lib/python2.7/wsgiref/simple_server.py", line 36, in close
    SimpleHandler.close(self)
  File "/usr/lib/python2.7/wsgiref/handlers.py", line 259, in close
    self.result.close()
  File "/usr/local/lib/python2.7/dist-packages/django/http/response.py", line 254, in close
    signals.request_finished.send(sender=self._handler_class)
  File "/usr/local/lib/python2.7/dist-packages/django/dispatch/dispatcher.py", line 191, in send
    response = receiver(signal=self, sender=sender, **named)
  File "/usr/local/lib/python2.7/dist-packages/django/core/cache/__init__.py", line 123, in close_caches
    cache.close()
  File "/usr/local/lib/python2.7/dist-packages/django_redis/cache.py", line 32, in _decorator
    return method(self, *args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/django_redis/cache.py", line 151, in close
    self.client.close(**kwargs)
  File "/usr/local/lib/python2.7/dist-packages/django_redis/client/default.py", line 508, in close
    for c in self.client.connection_pool._available_connections:
AttributeError: 'DefaultClient' object has no attribute 'client'
```