### PR TITLE
Fix invalid escape sequence deprecation warning

### DIFF
--- a/django_redis/client/sharded.py
+++ b/django_redis/client/sharded.py
@@ -17,7 +17,7 @@ from .default import DefaultClient, DEFAULT_TIMEOUT
 
 
 class ShardClient(DefaultClient):
-    _findhash = re.compile('.*\{(.*)\}.*', re.I)
+    _findhash = re.compile(r'.*\{(.*)\}.*', re.I)
 
     def __init__(self, *args, **kwargs):
         super(ShardClient, self).__init__(*args, **kwargs)


### PR DESCRIPTION
Appears during tests:

```
DeprecationWarning: invalid escape sequence \{
```

https://docs.python.org/3/whatsnew/3.6.html#deprecated-python-behavior

> A backslash-character pair that is not a valid escape sequence now
  generates a DeprecationWarning. Although this will eventually become a
  SyntaxError, that will not be for several Python
  releases. (Contributed by Emanuel Barry in bpo-27364.)