### PR TITLE
Include changelog in source tarball.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include LICENSE
 include AUTHORS.rst
 include README.rst
+include CHANGES.txt
 recursive-include tests README.txt *.py
 recursive-include doc Makefile *.adoc *.html


### PR DESCRIPTION
Debian has the option for binary packages to include a separate upstream
changelog in parallel to the Debian one. Having this file in the source tarball
would allow the Debian package to have both changelogs present.