### PR TITLE
Rename section to [bdist_wheel] as [wheel] is considered legacy

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
+[bdist_wheel]
+universal = 1
+
 [flake8]
 ignore = W601
 max-line-length = 119
-
-[wheel]
-universal = 1


### PR DESCRIPTION
See:

https://bitbucket.org/pypa/wheel/src/54ddbcc9cec25e1f4d111a142b8bfaa163130a61/wheel/bdist_wheel.py?fileviewer=file-view-default#bdist_wheel.py-119:125