### PR TITLE
Removed support for Django 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,6 @@ matrix:
     - python: 3.5
       env: DJANGO="Django>=1.8,<1.9"
     - python: 2.7
-      env: DJANGO="Django>=1.9,<1.10"
-    - python: 3.4
-      env: DJANGO="Django>=1.9,<1.10"
-    - python: 3.5
-      env: DJANGO="Django>=1.9,<1.10"
-    - python: 2.7
       env: DJANGO="Django>=1.10,<1.11"
     - python: 3.4
       env: DJANGO="Django>=1.10,<1.11"

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ setup(
         "Environment :: Web Environment",
         "Framework :: Django",
         "Framework :: Django :: 1.8",
-        "Framework :: Django :: 1.9",
         "Framework :: Django :: 1.10",
         "Framework :: Django :: 1.11",
         "Intended Audience :: Developers",

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
-envlist = {py27,pypy}-django{18,19,110,111},
+envlist = {py27,pypy}-django{18,110,111},
           py33-django18
-          {py34,py35,pypy3}-django{18,19,110,111}
+          {py34,py35,pypy3}-django{18,110,111}
           py36-django111
 
 [testenv]
@@ -15,7 +15,6 @@ commands =
 
 deps =
     django18: Django>=1.8,<1.9
-    django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
     django111: Django>=1.11,<2.0
     mock


### PR DESCRIPTION
Django 1.9 reached its end of life in April 2017; see https://www.djangoproject.com/weblog/2017/apr/04/security-releases/