### PR TITLE
Fixes #264 - Use FLUSHDB to clear cache.

### DIFF
--- a/django_redis/client/default.py
+++ b/django_redis/client/default.py
@@ -297,11 +297,7 @@ class DefaultClient(object):
             client = self.get_client(write=True)
 
         try:
-            count = 0
-            for key in client.scan_iter("*"):
-                client.delete(key)
-                count += 1
-            return count
+            client.flushdb()
         except _main_exceptions as e:
             raise ConnectionInterrupted(connection=client, parent=e)
 


### PR DESCRIPTION
Use [`FLUSHDB`](https://redis.io/commands/flushdb) instead of `SCAN` and `DEL` to clear the cache.

## Background

With a few cache keys (ie.. thousands) the `SCAN`/`DEL` approach works fine, however when you have millions of cache keys this approach can take quite some time to complete. Using `FLUSHDB` sends just a single command to the server. While `DEL key1 key2 key3 ...` has the same time complexity as `FLUSHDB` I believe `FLUSHDB` is the correct approach to use as it doesn't require first locating all keys (in django-redis' case using `SCAN`).

## Backwards Compatibility Break

Note that `FLUSHDB` doesn't give you a count of how many keys have been removed thus I've had to remove this behaviour. Note that none of the official Django cache backends return a count of keys removed when you call `clear` thus I think this really just brings django-redis closer to "spec" however this may of course been an undocumented feature some users were relying on.
