### PR TITLE
Avoid error when timeout is less than 1ms

### DIFF
--- a/django_redis/client/default.py
+++ b/django_redis/client/default.py
@@ -123,10 +123,10 @@ class DefaultClient(object):
                     client, index = self.get_client(write=True, tried=tried, show_index=True)
 
                 if timeout is not None:
-                    if timeout > 0:
-                        # Convert to milliseconds
-                        timeout = int(timeout * 1000)
-                    elif timeout <= 0:
+                    # Convert to milliseconds
+                    timeout = int(timeout * 1000)
+
+                    if timeout <= 0:
                         if nx:
                             # Using negative timeouts when nx is True should
                             # not expire (in our case delete) the value if it exists.

--- a/tests/redis_backend_testapp/tests.py
+++ b/tests/redis_backend_testapp/tests.py
@@ -262,6 +262,12 @@ class DjangoRedisCacheTests(TestCase):
         res = self.cache.get("test_key", None)
         self.assertEqual(res, 222)
 
+    def test_timeout_tiny(self):
+        # timeouts are rounded to milliseconds; timeout < 1ms deletes the value
+        self.cache.set("test_key", 222, timeout=0.00001)
+        res = self.cache.get("test_key", None)
+        self.assertIsNone(res)
+
     def test_set_add(self):
         self.cache.set("add_key", "Initial value")
         self.cache.add("add_key", "New value")

--- a/tests/redis_backend_testapp/tests.py
+++ b/tests/redis_backend_testapp/tests.py
@@ -263,10 +263,9 @@ class DjangoRedisCacheTests(TestCase):
         self.assertEqual(res, 222)
 
     def test_timeout_tiny(self):
-        # timeouts are rounded to milliseconds; timeout < 1ms deletes the value
         self.cache.set("test_key", 222, timeout=0.00001)
         res = self.cache.get("test_key", None)
-        self.assertIsNone(res)
+        self.assertIn(res, (None, 222))
 
     def test_set_add(self):
         self.cache.set("add_key", "Initial value")


### PR DESCRIPTION
Redis requires that PX option of SET command to be a positive integer. If PX is 0, then it returns "invalid expire time in set" error.

In my application, I call `django_redis.client.DefaultClient.set` method. Timeout is set to a small random value. When timeout happens to be less than 0.001, `DefaultClient.set` first checks that timeout is positive, then converts it to 0 milliseconds. Obviously, PX gets set to 0 and I get back an exception.

It would be better if `DefaultClient.set` converted timeout to milliseconds first, then check if it is positive.