### PR TITLE
Changed docstring for .incr() according to redis INCRBY docs

### DIFF
--- a/django_redis/client/default.py
+++ b/django_redis/client/default.py
@@ -54,7 +54,7 @@ class DefaultClient(object):
         self.connection_factory = pool.get_connection_factory(options=self._options)
 
     def __contains__(self, key):
-        return self.has_key(key)
+        return key in self
 
     def get_next_client_index(self, write=True, tried=()):
         """
@@ -393,8 +393,6 @@ class DefaultClient(object):
                 else return false end
                 """
                 value = client.eval(lua, 1, key, delta)
-                if value is None:
-                    raise ValueError("Key '%s' not found" % key)
             except ResponseError:
                 # if cached value or total value is greater than 64 bit signed
                 # integer.
@@ -418,15 +416,15 @@ class DefaultClient(object):
 
     def incr(self, key, delta=1, version=None, client=None):
         """
-        Add delta to value in the cache. If the key does not exist, raise a
-        ValueError exception.
+        Add delta to value in the cache. If the key does not exist,
+        it is set to 0 before performing the operation.
         """
         return self._incr(key=key, delta=delta, version=version, client=client)
 
     def decr(self, key, delta=1, version=None, client=None):
         """
-        Decreace delta to value in the cache. If the key does not exist, raise a
-        ValueError exception.
+        Subtract delta from value in the cache. If the key does not exist,
+        it is set to 0 before performing the operation.
         """
         return self._incr(key=key, delta=-delta, version=version,
                           client=client)

--- a/django_redis/client/default.py
+++ b/django_redis/client/default.py
@@ -54,7 +54,7 @@ class DefaultClient(object):
         self.connection_factory = pool.get_connection_factory(options=self._options)
 
     def __contains__(self, key):
-        return key in self
+        return self.has_key(key)
 
     def get_next_client_index(self, write=True, tried=()):
         """


### PR DESCRIPTION
I was looking for the behavior of incrementing a key or create it if it doesn't exist, exactly like INCRBY:
https://redis.io/commands/incrby

Unfortunately, the docstring in django_redis said `.incr()` would actually raise an error if I use it... but then I saw it's actually using `INCRBY` in `._incr()`, so it actually does exactly what I want, the docstring just needs updating. I also removed the obsolete check for 'Key not found' since it would never happen.

Django seems to suggest that `.incr()` should raise an error if the key doesn't exist; I don't know how closely you  want to follow the Django recommended behavior for this, but I'm keeping the behavior as-is in my personal fork since it's exactly what I want :+1: 