### PR TITLE
Add Django to list of install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
     ],
     description=description.strip(),
     install_requires=[
+        "Django>=1.8",
         "redis>=2.10.0",
     ],
     zip_safe=False,


### PR DESCRIPTION
Django is a requirement of django-redis, so it should be listed.