### PR TITLE
Fix tests and tox configuration to run successfully

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,12 +35,12 @@ before_script:
   - flake8
 
 script:
-  - (cd tests && python runtests.py)
-  - (cd tests && python runtests-sharded.py)
-  - (cd tests && python runtests-herd.py)
-  - (cd tests && python runtests-json.py)
-  - (cd tests && python runtests-msgpack.py)
-  - (cd tests && python runtests-zlib.py)
+  - python tests/runtests.py
+  - python tests/runtests-sharded.py
+  - python tests/runtests-herd.py
+  - python tests/runtests-json.py
+  - python tests/runtests-msgpack.py
+  - python tests/runtests-zlib.py
 
 services:
   - redis-server

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",

--- a/tests/runtests-fakeredis.py
+++ b/tests/runtests-fakeredis.py
@@ -3,9 +3,8 @@
 import os
 import sys
 
-sys.path.insert(0, '..')
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "test_fakeredis")
-
 
 if __name__ == "__main__":
     from django.core.management import execute_from_command_line

--- a/tests/runtests-herd.py
+++ b/tests/runtests-herd.py
@@ -3,9 +3,8 @@
 import os
 import sys
 
-sys.path.insert(0, '..')
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "test_sqlite_herd")
-
 
 if __name__ == "__main__":
     from django.core.management import execute_from_command_line

--- a/tests/runtests-json.py
+++ b/tests/runtests-json.py
@@ -3,7 +3,7 @@
 import os
 import sys
 
-sys.path.insert(0, "..")
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "test_sqlite_json")
 
 if __name__ == "__main__":

--- a/tests/runtests-msgpack.py
+++ b/tests/runtests-msgpack.py
@@ -3,7 +3,7 @@
 import os
 import sys
 
-sys.path.insert(0, "..")
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "test_sqlite_msgpack")
 
 if __name__ == "__main__":

--- a/tests/runtests-sharded.py
+++ b/tests/runtests-sharded.py
@@ -3,7 +3,7 @@
 import os
 import sys
 
-sys.path.insert(0, '..')
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "test_sqlite_sharding")
 
 if __name__ == "__main__":

--- a/tests/runtests-unixsockets.py
+++ b/tests/runtests-unixsockets.py
@@ -3,9 +3,8 @@
 import os
 import sys
 
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "test_sqlite_usock")
-sys.path.insert(0, 'tests')
-
 
 if __name__ == "__main__":
     from django.core.management import execute_from_command_line

--- a/tests/runtests-zlib.py
+++ b/tests/runtests-zlib.py
@@ -3,7 +3,7 @@
 import os
 import sys
 
-sys.path.insert(0, "..")
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "test_sqlite_zlib")
 
 if __name__ == "__main__":

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -3,7 +3,7 @@
 import os
 import sys
 
-sys.path.insert(0, "..")
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "test_sqlite")
 
 if __name__ == "__main__":

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
-envlist = {py27,pypy}-django{18,110,111},
-          py33-django18
-          {py34,py35,pypy3}-django{18,110,111}
-          py36-django111
+envlist =
+    py{27,33,34,35}-django18
+    py{27,34,35}-django110
+    py{27,34,35,36}-django111
 
 [testenv]
 commands =
@@ -17,6 +17,7 @@ deps =
     django18: Django>=1.8,<1.9
     django110: Django>=1.10,<1.11
     django111: Django>=1.11,<2.0
+    fakeredis
     mock
     msgpack-python>=0.4.6
     redis>=2.10.0


### PR DESCRIPTION
Previously, tox was executing 0 tests.

Reorganize the envlist in terms of Django versions. Much easier to keep organized and (when it is time) drop outdated version. The tox and Travis matrix now match.

Required adding missing dependency to tox configuration.

Add missing supported Python version to trove classifiers. Python 3.3 is still being tested by tox and Travis CI.