### PR TITLE
Escape prefix and version in glob expressions

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+UNRELEASED
+----------
+
+- Escape `KEY_PREFIX` and `VERSION` when used in glob expressions.
+
 Version 4.8.0
 -------------
 

--- a/tests/test_fakeredis.py
+++ b/tests/test_fakeredis.py
@@ -42,7 +42,7 @@ CACHES = {
     },
     "with_prefix": {
         "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": "127.0.0.1:6379:1",
+        "LOCATION": "redis://127.0.0.1:6379?db=1",
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
             "REDIS_CLIENT_CLASS": "fakeredis.FakeStrictRedis",

--- a/tests/test_sqlite.py
+++ b/tests/test_sqlite.py
@@ -39,7 +39,7 @@ CACHES = {
     },
     "with_prefix": {
         "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": "127.0.0.1:6379:1",
+        "LOCATION": "redis://127.0.0.1:6379?db=1",
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
         },

--- a/tests/test_sqlite_herd.py
+++ b/tests/test_sqlite_herd.py
@@ -52,7 +52,7 @@ CACHES = {
     },
     "with_prefix": {
         "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": "127.0.0.1:6379:1",
+        "LOCATION": "redis://127.0.0.1:6379?db=1",
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.HerdClient",
         },

--- a/tests/test_sqlite_json.py
+++ b/tests/test_sqlite_json.py
@@ -42,7 +42,7 @@ CACHES = {
     },
     "with_prefix": {
         "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": "127.0.0.1:6379:1",
+        "LOCATION": "redis://127.0.0.1:6379?db=1",
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
             "SERIALIZER": "django_redis.serializers.json.JSONSerializer",

--- a/tests/test_sqlite_msgpack.py
+++ b/tests/test_sqlite_msgpack.py
@@ -42,7 +42,7 @@ CACHES = {
     },
     "with_prefix": {
         "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": "127.0.0.1:6379:1",
+        "LOCATION": "redis://127.0.0.1:6379?db=1",
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
             "SERIALIZER": "django_redis.serializers.msgpack.MSGPackSerializer",

--- a/tests/test_sqlite_sharding.py
+++ b/tests/test_sqlite_sharding.py
@@ -55,7 +55,7 @@ CACHES = {
     },
     "with_prefix": {
         "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": "127.0.0.1:6379:1",
+        "LOCATION": "redis://127.0.0.1:6379?db=1",
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.ShardClient",
         },

--- a/tests/test_sqlite_usock.py
+++ b/tests/test_sqlite_usock.py
@@ -52,7 +52,7 @@ CACHES = {
     },
     "with_prefix": {
         "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": "127.0.0.1:6379:1",
+        "LOCATION": "redis://127.0.0.1:6379?db=1",
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
         },

--- a/tests/test_sqlite_zlib.py
+++ b/tests/test_sqlite_zlib.py
@@ -42,7 +42,7 @@ CACHES = {
     },
     "with_prefix": {
         "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": "127.0.0.1:6379:1",
+        "LOCATION": "redis://127.0.0.1:6379?db=1",
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
             "COMPRESSOR": "django_redis.compressors.zlib.ZlibCompressor",


### PR DESCRIPTION
A prefix containing a * should be escaped and not interpreted as a glob pattern.