### PR TITLE
compatibility with migration from py2 to py3 while preserving cache

### DIFF
--- a/django_redis/serializers/pickle.py
+++ b/django_redis/serializers/pickle.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import absolute_import, unicode_literals
+from ..compat import PY3
 
 # Import the fastest implementation of
 # pickle package. This should be removed
@@ -33,4 +34,6 @@ class PickleSerializer(BaseSerializer):
         return pickle.dumps(value, self._pickle_version)
 
     def loads(self, value):
+        if PY3:
+            return pickle.loads(force_bytes(value), fix_imports=True, encoding='bytes')
         return pickle.loads(force_bytes(value))


### PR DESCRIPTION
When I migrate from py2 to py3, py3's `pickle.loads` fails when it attempts to decode with ascii encoding as [its documentation](https://docs.python.org/3/library/pickle.html#pickle.loads) details. 

I'm not entirely sure why the existing codebase works on py3 with py3 serialized objects and not py2. It may be that py3 somehow serializes with 7-bit encoding, so that it's ascii compatible, and py2 with 8-bit bytes encoding? There's [an issue](https://github.com/niwinz/django-redis/issues/184) that was opened for this problem, and while the reporter was able to resolve by flushing the cache, we need to preserve our cache through our migration from py2 to py3, so I wanted to fix this issue.