### PR TITLE
Add datetime module serialization support to the JSON serializer

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,8 @@ UNRELEASED
 - Escape `KEY_PREFIX` and `VERSION` when used in glob expressions.
 - Improve handling timeouts less than 1ms.
 - Remove fakeredis support.
+- Add datetime, date, time, and timedelta serialization support to the JSON
+  serializer.
 
 
 Version 4.8.0

--- a/django_redis/serializers/json.py
+++ b/django_redis/serializers/json.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, unicode_literals
 
 import json
 
+from django.core.serializers.json import DjangoJSONEncoder
 from django.utils.encoding import force_bytes, force_text
 
 from .base import BaseSerializer
@@ -11,7 +12,7 @@ from .base import BaseSerializer
 
 class JSONSerializer(BaseSerializer):
     def dumps(self, value):
-        return force_bytes(json.dumps(value))
+        return force_bytes(json.dumps(value, cls=DjangoJSONEncoder))
 
     def loads(self, value):
         return json.loads(force_text(value))

--- a/tests/redis_backend_testapp/tests.py
+++ b/tests/redis_backend_testapp/tests.py
@@ -20,9 +20,8 @@ from django.utils import six, timezone
 import django_redis.cache
 from django_redis import pool
 from django_redis.client import DefaultClient, ShardClient, herd
-from django_redis.serializers import (
-    json as json_serializer, msgpack as msgpack_serializer,
-)
+from django_redis.serializers.json import JSONSerializer
+from django_redis.serializers.msgpack import MSGPackSerializer
 
 try:
     from unittest.mock import patch, Mock
@@ -219,14 +218,9 @@ class DjangoRedisCacheTests(TestCase):
         self.assertEqual(res, "heló")
 
     def test_save_dict(self):
-        if isinstance(self.cache.client._serializer,
-                      json_serializer.JSONSerializer):
-            self.skipTest("Datetimes are not JSON serializable")
-
-        if isinstance(self.cache.client._serializer,
-                      msgpack_serializer.MSGPackSerializer):
-            # MSGPackSerializer serializers use the isoformat for datetimes
-            # https://github.com/msgpack/msgpack-python/issues/12
+        if isinstance(self.cache.client._serializer, (JSONSerializer, MSGPackSerializer)):
+            # JSONSerializer and MSGPackSerializer use the isoformat for
+            # datetimes.
             now_dt = datetime.datetime.now().isoformat()
         else:
             now_dt = datetime.datetime.now()


### PR DESCRIPTION
Use Django's `DjangoJSONEncoder` to encode the types from the `datetime` module.

https://docs.djangoproject.com/en/1.11/topics/serialization/#djangojsonencoder

> datetime
>     A string of the form YYYY-MM-DDTHH:mm:ss.sssZ or
>     YYYY-MM-DDTHH:mm:ss.sss+HH:MM as defined in ECMA-262.
> date
>     A string of the form YYYY-MM-DD as defined in ECMA-262.
> time
>     A string of the form HH:MM:ss.sss as defined in ECMA-262.
> timedelta
>     A string representing a duration as defined in ISO-8601. For
>     example, timedelta(days=1, hours=2, seconds=3.4) is represented as
>     'P1DT02H00M03.400000S'.