### PR TITLE
Remove unnecessary force_bytes() call

### DIFF
--- a/django_redis/serializers/pickle.py
+++ b/django_redis/serializers/pickle.py
@@ -3,7 +3,6 @@
 from __future__ import absolute_import, unicode_literals
 
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.encoding import force_bytes
 
 from .base import BaseSerializer
 
@@ -33,4 +32,4 @@ class PickleSerializer(BaseSerializer):
         return pickle.dumps(value, self._pickle_version)
 
     def loads(self, value):
-        return pickle.loads(force_bytes(value))
+        return pickle.loads(value)


### PR DESCRIPTION
The Python Redis library always returns values as `bytes` (str on Python 2). There is no need to coerce those `bytes` to `bytes` again with a call to `force_bytes()`. It is always a noop.