### PR TITLE
Remove test settings that are unused or don't matter

### DIFF
--- a/tests/test_sqlite.py
+++ b/tests/test_sqlite.py
@@ -5,12 +5,6 @@ DATABASES = {
 }
 
 SECRET_KEY = "django_tests_secret_key"
-TIME_ZONE = "America/Chicago"
-LANGUAGE_CODE = "en-us"
-ADMIN_MEDIA_PREFIX = "/static/admin/"
-STATICFILES_DIRS = ()
-
-MIDDLEWARE_CLASSES = []
 
 CACHES = {
     "default": {

--- a/tests/test_sqlite_herd.py
+++ b/tests/test_sqlite_herd.py
@@ -1,17 +1,3 @@
-# This is an example test settings file for use with the Django test suite.
-#
-# The 'sqlite3' backend requires only the ENGINE setting (an in-
-# memory database will be used). All other backends will require a
-# NAME and potentially authentication information. See the
-# following section in the docs for more information:
-#
-# https://docs.djangoproject.com/en/dev/internals/contributing/writing-code/unit-tests/
-#
-# The different databases that Django supports behave differently in certain
-# situations, so it is recommended to run the test suite against as many
-# database backends as possible.  You may want to create a separate settings
-# file for each of the backends you test against.
-
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3'
@@ -19,12 +5,6 @@ DATABASES = {
 }
 
 SECRET_KEY = "django_tests_secret_key"
-TIME_ZONE = 'America/Chicago'
-LANGUAGE_CODE = 'en-us'
-ADMIN_MEDIA_PREFIX = '/static/admin/'
-STATICFILES_DIRS = ()
-
-MIDDLEWARE_CLASSES = []
 
 CACHES = {
     'default': {

--- a/tests/test_sqlite_json.py
+++ b/tests/test_sqlite_json.py
@@ -5,12 +5,6 @@ DATABASES = {
 }
 
 SECRET_KEY = "django_tests_secret_key"
-TIME_ZONE = "America/Chicago"
-LANGUAGE_CODE = "en-us"
-ADMIN_MEDIA_PREFIX = "/static/admin/"
-STATICFILES_DIRS = ()
-
-MIDDLEWARE_CLASSES = []
 
 CACHES = {
     "default": {

--- a/tests/test_sqlite_msgpack.py
+++ b/tests/test_sqlite_msgpack.py
@@ -5,12 +5,6 @@ DATABASES = {
 }
 
 SECRET_KEY = "django_tests_secret_key"
-TIME_ZONE = "America/Chicago"
-LANGUAGE_CODE = "en-us"
-ADMIN_MEDIA_PREFIX = "/static/admin/"
-STATICFILES_DIRS = ()
-
-MIDDLEWARE_CLASSES = []
 
 CACHES = {
     "default": {

--- a/tests/test_sqlite_sharding.py
+++ b/tests/test_sqlite_sharding.py
@@ -1,17 +1,3 @@
-# This is an example test settings file for use with the Django test suite.
-#
-# The 'sqlite3' backend requires only the ENGINE setting (an in-
-# memory database will be used). All other backends will require a
-# NAME and potentially authentication information. See the
-# following section in the docs for more information:
-#
-# https://docs.djangoproject.com/en/dev/internals/contributing/writing-code/unit-tests/
-#
-# The different databases that Django supports behave differently in certain
-# situations, so it is recommended to run the test suite against as many
-# database backends as possible.  You may want to create a separate settings
-# file for each of the backends you test against.
-
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3'
@@ -19,12 +5,7 @@ DATABASES = {
 }
 
 SECRET_KEY = "django_tests_secret_key"
-TIME_ZONE = 'America/Chicago'
-LANGUAGE_CODE = 'en-us'
-ADMIN_MEDIA_PREFIX = '/static/admin/'
-STATICFILES_DIRS = ()
 
-MIDDLEWARE_CLASSES = []
 CACHES = {
     'default': {
         'BACKEND': 'django_redis.cache.RedisCache',

--- a/tests/test_sqlite_usock.py
+++ b/tests/test_sqlite_usock.py
@@ -1,17 +1,3 @@
-# This is an example test settings file for use with the Django test suite.
-#
-# The 'sqlite3' backend requires only the ENGINE setting (an in-
-# memory database will be used). All other backends will require a
-# NAME and potentially authentication information. See the
-# following section in the docs for more information:
-#
-# https://docs.djangoproject.com/en/dev/internals/contributing/writing-code/unit-tests/
-#
-# The different databases that Django supports behave differently in certain
-# situations, so it is recommended to run the test suite against as many
-# database backends as possible.  You may want to create a separate settings
-# file for each of the backends you test against.
-
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3'
@@ -19,11 +5,6 @@ DATABASES = {
 }
 
 SECRET_KEY = "django_tests_secret_key"
-TIME_ZONE = 'America/Chicago'
-LANGUAGE_CODE = 'en-us'
-ADMIN_MEDIA_PREFIX = '/static/admin/'
-STATICFILES_DIRS = ()
-MIDDLEWARE_CLASSES = []
 
 CACHES = {
     'default': {

--- a/tests/test_sqlite_zlib.py
+++ b/tests/test_sqlite_zlib.py
@@ -5,12 +5,6 @@ DATABASES = {
 }
 
 SECRET_KEY = "django_tests_secret_key"
-TIME_ZONE = "America/Chicago"
-LANGUAGE_CODE = "en-us"
-ADMIN_MEDIA_PREFIX = "/static/admin/"
-STATICFILES_DIRS = ()
-
-MIDDLEWARE_CLASSES = []
 
 CACHES = {
     "default": {


### PR DESCRIPTION
They only add noise to many test settings files. Simplify the test configuration by removing them. Make the many settings files more similar to each other. Less to maintain.

Settings removed:

- `ADMIN_MEDIA_PREFIX`
- `LANGUAGE_CODE`
- `MIDDLEWARE_CLASSES`
- `STATICFILES_DIRS`
- `TIME_ZONE`

Removed large boilerplate comment.