### PR TITLE
Be more explicit about types in the JSONSerializer

### DIFF
--- a/django_redis/serializers/json.py
+++ b/django_redis/serializers/json.py
@@ -5,14 +5,13 @@ from __future__ import absolute_import, unicode_literals
 import json
 
 from django.core.serializers.json import DjangoJSONEncoder
-from django.utils.encoding import force_bytes, force_text
 
 from .base import BaseSerializer
 
 
 class JSONSerializer(BaseSerializer):
     def dumps(self, value):
-        return force_bytes(json.dumps(value, cls=DjangoJSONEncoder))
+        return json.dumps(value, cls=DjangoJSONEncoder).encode()
 
     def loads(self, value):
-        return json.loads(force_text(value))
+        return json.loads(value.decode())


### PR DESCRIPTION
Always return utf-8 encoded bytes in dumps. The Redis connection will pass it as is. Always expected utf-8 encoded bytes in loads. This makes the functions inverses of one another.

Using `force_bytes()`/`force_text()` implies an unknown input/output, but the input/output is always known. It should always be bytes.