### PR TITLE
Remove long deprecated feature of passing timeout=True

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -10,6 +10,8 @@ UNRELEASED
 - Remove fakeredis support.
 - Add datetime, date, time, and timedelta serialization support to the JSON
   serializer.
+- The deprecated feature of passing `True` as a timeout value is no longer
+  supported.
 
 
 Version 4.8.0

--- a/django_redis/client/default.py
+++ b/django_redis/client/default.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import, unicode_literals
 import random
 import re
 import socket
-import warnings
 from collections import OrderedDict
 
 from django.conf import settings
@@ -113,10 +112,6 @@ class DefaultClient(object):
         """
         nkey = self.make_key(key, version=version)
         nvalue = self.encode(value)
-
-        if timeout is True:
-            warnings.warn("Using True as timeout value, is now deprecated.", DeprecationWarning)
-            timeout = self._backend.default_timeout
 
         if timeout == DEFAULT_TIMEOUT:
             timeout = self._backend.default_timeout


### PR DESCRIPTION
Was deprecated in commit 49b2f358a7183dea1d19777ec9758f46e93105f5 on 2014-01-12 in version 3.5.0.