### PR TITLE
Fix add() with a negative timeout

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,6 +12,8 @@ UNRELEASED
   serializer.
 - The deprecated feature of passing `True` as a timeout value is no longer
   supported.
+- Fix `add()` with a negative timeout to not store key (it is immediately
+  invalid).
 
 
 Version 4.8.0

--- a/django_redis/client/default.py
+++ b/django_redis/client/default.py
@@ -132,7 +132,7 @@ class DefaultClient(object):
                             # Using negative timeouts when nx is True should
                             # not expire (in our case delete) the value if it exists.
                             # Obviously expire not existent value is noop.
-                            timeout = None
+                            return not self.has_key(key, version=version, client=client)
                         else:
                             # redis doesn't support negative timeouts in ex flags
                             # so it seems that it's better to just delete the key

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -12,7 +12,7 @@ from datetime import timedelta
 from django import VERSION
 from django.conf import settings
 from django.contrib.sessions.backends.cache import SessionStore as CacheSession
-from django.core.cache import cache, caches
+from django.core.cache import DEFAULT_CACHE_ALIAS, cache, caches
 from django.test import TestCase, override_settings
 from django.test.utils import patch_logger
 from django.utils import six, timezone
@@ -269,7 +269,7 @@ class DjangoRedisCacheTests(TestCase):
         self.assertEqual(res2, None)
 
         # nx=True should not overwrite expire of key already in db
-        self.cache.set("test_key", 222, 0)
+        self.cache.set("test_key", 222, None)
         self.cache.set("test_key", 222, -1, nx=True)
         res = self.cache.get("test_key", None)
         self.assertEqual(res, 222)
@@ -279,13 +279,13 @@ class DjangoRedisCacheTests(TestCase):
         res = self.cache.get("test_key", None)
         self.assertIsNone(res)
 
-        self.cache.set("test_key", 222, timeout=0)
+        self.cache.set("test_key", 222, timeout=None)
         self.cache.set("test_key", 222, timeout=-1)
         res = self.cache.get("test_key", None)
         self.assertIsNone(res)
 
         # nx=True should not overwrite expire of key already in db
-        self.cache.set("test_key", 222, timeout=0)
+        self.cache.set("test_key", 222, timeout=None)
         self.cache.set("test_key", 222, timeout=-1, nx=True)
         res = self.cache.get("test_key", None)
         self.assertEqual(res, 222)
@@ -929,7 +929,9 @@ class SessionTests(SessionTestsMixin, TestCase):
     backend = CacheSession
 
     def test_actual_expiry(self):
-        pass
+        if isinstance(caches[DEFAULT_CACHE_ALIAS].client._serializer, MSGPackSerializer):
+            raise unittest.SkipTest("msgpack serializer doesn't support datetime serialization")
+        super(SessionTests, self).test_actual_expiry()
 
 
 class TestDefaultClient(TestCase):


### PR DESCRIPTION
Adding to the cache with a negative timeout should be immediately invalid. So don't bother adding it. The add is considered failed if the key does not exist.

Fixing this allowed restoring a test from Django's session test suite, `SessionTestsMixin.test_actual_expiry`. Using django-redis as a cache with the Session cache backend is now in full compliance.