### PR TITLE
Pin lz4 package until latest upstream is installable from PyPI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ mock
 msgpack-python>=0.4.6
 redis>=2.10.0
 wheel
-lz4
+lz4==0.13

--- a/tox.ini
+++ b/tox.ini
@@ -23,4 +23,4 @@ deps =
     mock
     msgpack-python>=0.4.6
     redis>=2.10.0
-    lz4
+    lz4==0.13


### PR DESCRIPTION
Workaround for upstream issue:

https://github.com/python-lz4/python-lz4/issues/75