### PR TITLE
Remove empty test

### DIFF
--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -599,9 +599,6 @@ class DjangoRedisCacheTests(TestCase):
         except NotImplementedError:
             pass
 
-    def test_zlib_compressor(self):
-        pass
-
 
 class DjangoOmitExceptionsTests(TestCase):
     def setUp(self):


### PR DESCRIPTION
Testing zlib compression is handled by `tests/runtests-zlib.py`. The empty test `test_zlib_compressor` does not test anything and can be removed.