### PR TITLE
Run Travis CI through the tox configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,50 +5,40 @@ cache: pip
 matrix:
   include:
     - python: 2.7
-      env: DJANGO="Django>=1.8,<1.9"
+      env: TOXENV=py27-django18
     - python: 3.3
-      env: DJANGO="Django>=1.8,<1.9"
+      env: TOXENV=py33-django18
     - python: 3.4
-      env: DJANGO="Django>=1.8,<1.9"
+      env: TOXENV=py34-django18
     - python: 3.5
-      env: DJANGO="Django>=1.8,<1.9"
+      env: TOXENV=py35-django18
     - python: 2.7
-      env: DJANGO="Django>=1.10,<1.11"
+      env: TOXENV=py27-django110
     - python: 3.4
-      env: DJANGO="Django>=1.10,<1.11"
+      env: TOXENV=py34-django110
     - python: 3.5
-      env: DJANGO="Django>=1.10,<1.11"
+      env: TOXENV=py35-django110
     - python: 2.7
-      env: DJANGO="Django>=1.11,<2.0"
+      env: TOXENV=py27-django111
     - python: 3.4
-      env: DJANGO="Django>=1.11,<2.0"
+      env: TOXENV=py34-django111
     - python: 3.5
-      env: DJANGO="Django>=1.11,<2.0"
+      env: TOXENV=py35-django111
     - python: 3.6
-      env: DJANGO="Django>=1.11,<2.0"
+      env: TOXENV=py36-django111
     - python: 3.4
-      env: DJANGO="Django>=2.0,<2.1"
+      env: TOXENV=py34-django20
     - python: 3.5
-      env: DJANGO="Django>=2.0,<2.1"
+      env: TOXENV=py35-django20
     - python: 3.6
-      env: DJANGO="Django>=2.0,<2.1"
+      env: TOXENV=py36-django20
+    - env: TOXENV=lint
 
 install:
-  - pip install $DJANGO
-  - pip install -r requirements.txt
-
-before_script:
-  - flake8 django_redis tests
-  - isort --check-only --diff --recursive django_redis tests
+  - pip install tox
 
 script:
-  - python tests/runtests.py
-  - python tests/runtests-sharded.py
-  - python tests/runtests-herd.py
-  - python tests/runtests-json.py
-  - python tests/runtests-msgpack.py
-  - python tests/runtests-zlib.py
-  - python tests/runtests-lz4.py
+  - tox
 
 services:
   - redis-server

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist =
+    lint
     py{27,33,34,35}-django18
     py{27,34,35}-django110
     py{27,34,35,36}-django111
@@ -24,3 +25,12 @@ deps =
     msgpack-python>=0.4.6
     redis>=2.10.0
     lz4==0.13
+
+[testenv:lint]
+basepython = python3
+commands =
+    flake8 django_redis tests
+    isort --check-only --diff --recursive django_redis tests
+deps =
+    flake8
+    isort


### PR DESCRIPTION
Removes duplication of testing environments. Testing locally with tox now better matches the Travis CI environment.