### PR TITLE
Add error threshold - better explanation

### DIFF
--- a/django_redis/cache.py
+++ b/django_redis/cache.py
@@ -64,7 +64,9 @@ class RedisCache(BaseCache):
         self._client = None
 
         self._ignore_exceptions = options.get("IGNORE_EXCEPTIONS", DJANGO_REDIS_IGNORE_EXCEPTIONS)
-        self._exception_threshold = float(options.get("EXCEPTION_THRESHOLD", DJANGO_REDIS_EXCEPTION_THRESHOLD))
+        self._exception_threshold = options.get("EXCEPTION_THRESHOLD", DJANGO_REDIS_EXCEPTION_THRESHOLD)
+        if self._exception_threshold is not None:
+            self._exception_threshold = float(self._exception_threshold)
         self._exception_threshold_cooldown = float(options.get(
             "EXCEPTION_THRESHOLD_COOLDOWN", DJANGO_REDIS_EXCEPTION_THRESHOLD_COOLDOWN))
         self._exception_threshold_time_window = float(options.get(


### PR DESCRIPTION
I know you closed the previous request, but I feel like I did not explain the reason I had to implement this which hopefully justifies the complexity. In my case the lack of this feature caused a production level outage.

When you have multiple cache calls in a request, both timeouts and ignore exceptions are set and redis becomes unavailable, the request hangs until all the timeouts resolve. Through multiple requests, each with multiple cache hits (such as someone spamming refresh) this can ended up hanging the whole server.

I want ignore_exceptions to allow the cache to function as if there was no data returned on error, but still allow for occasional network stutters by having a timeout set to nonzero.

The thresholding I suggest allows you to fail fast when you have a redis outtage and prevent hanging.

If you have suggestions to reduce complexity and solve the issue I'd find that useful. I have been using my fork in prod since October.

P.S. Thanks for all the work on this, its really a great lib and great documentation.
