### PR TITLE
Remove usage of deprecated `get_cache` method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,13 @@
 language: python
 
 python:
+  - "3.6"
+  - "3.5"
   - "3.4"
-  - "3.3"
   - "2.7"
 
 env:
-  - DJANGO="django==1.7.1"
-  - DJANGO="django==1.6.3"
-  - DJANGO="django==1.5.7"
-  - DJANGO="django==1.4.12"
-  - DJANGO="django==1.8"
-
-matrix:
-  exclude:
-    - python: "3.3"
-      env: DJANGO="django==1.4.12"
-    - python: "3.4"
-      env: DJANGO="django==1.4.12"
+  - DJANGO="django==1.11.11"
 
 install:
   - pip install $DJANGO --use-mirrors

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ env:
   - DJANGO="django==1.11.11"
 
 install:
-  - pip install $DJANGO --use-mirrors
-  - pip install redis==2.10.3 --use-mirrors
+  - pip install $DJANGO
+  - pip install redis==2.10.3
   - pip install mock==1.0.1
 
 script:

--- a/django_redis/__init__.py
+++ b/django_redis/__init__.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 
-from django.core.cache import get_cache
+from django.core.cache import caches
 
 def get_redis_connection(alias='default', write=True):
     """
     Helper used for obtain a raw redis client.
     """
 
-    cache = get_cache(alias)
+    cache = caches[alias]
     if not hasattr(cache.client, 'get_client'):
         raise NotImplementedError("This backend does not supports this feature")
 

--- a/tests/redis_backend_testapp/tests.py
+++ b/tests/redis_backend_testapp/tests.py
@@ -12,7 +12,7 @@ except ImportError:
     from mock import patch
 
 from django.conf import settings
-from django.core.cache import cache, get_cache
+from django.core.cache import cache, caches
 from django.test import TestCase
 
 import django_redis.cache
@@ -84,7 +84,7 @@ class DjangoRedisCacheTestCustomKeyFunction(TestCase):
         settings.CACHES['default']['KEY_FUNCTION'] = 'redis_backend_testapp.tests.make_key'
         settings.CACHES['default']['REVERSE_KEY_FUNCTION'] = 'redis_backend_testapp.tests.reverse_key'
 
-        self.cache = get_cache('default')
+        self.cache = caches['default']
         try:
             self.cache.clear()
         except Exception:
@@ -418,12 +418,12 @@ class DjangoRedisCacheTests(TestCase):
         self.assertFalse(bool(res))
 
     def test_close(self):
-        cache = get_cache("default")
+        cache = caches["default"]
         cache.set("f", "1")
         cache.close()
 
     def test_ttl(self):
-        cache = get_cache("default")
+        cache = caches["default"]
         _params = cache._params
         _is_herd = (_params["OPTIONS"]["CLIENT_CLASS"] ==
                     "django_redis.client.HerdClient")
@@ -457,7 +457,7 @@ class DjangoRedisCacheTests(TestCase):
         self.assertEqual(ttl, 0)
 
     def test_iter_keys(self):
-        cache = get_cache("default")
+        cache = caches["default"]
         _params = cache._params
         _is_shard = (_params["OPTIONS"]["CLIENT_CLASS"] ==
                     "django_redis.client.ShardClient")
@@ -483,7 +483,7 @@ class DjangoRedisCacheTests(TestCase):
 
     def test_master_slave_switching(self):
         try:
-            cache = get_cache("sample")
+            cache = caches["sample"]
             client = cache.client
             client._server = ["foo", "bar",]
             client._clients = ["Foo", "Bar"]
@@ -500,7 +500,7 @@ class DjangoOmitExceptionsTests(TestCase):
     def setUp(self):
         self._orig_setting = django_redis.cache.DJANGO_REDIS_IGNORE_EXCEPTIONS
         django_redis.cache.DJANGO_REDIS_IGNORE_EXCEPTIONS = True
-        self.cache = get_cache("doesnotexist")
+        self.cache = caches["doesnotexist"]
 
     def tearDown(self):
         django_redis.cache.DJANGO_REDIS_IGNORE_EXCEPTIONS = self._orig_setting

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
-envlist = {py27,pypy}-django{14,15,16,17,18},
-          {py33,py34,pypy3}-django{15,16,17,18}
+envlist = {py27,py34,py35,py36,pypy3}-django{111}
 
 [testenv]
 commands =
@@ -9,10 +8,6 @@ commands =
   python tests/runtests-herd.py -v2
 
 deps =
-    django14: Django>=1.4, <1.5
-    django15: Django>=1.5, <1.6
-    django16: Django>=1.6, <1.7
-    django17: Django>=1.7, <1.8
-    django18: Django==1.8
+    django111: Django>=1.11, <2.0
     mock==1.0.1
     redis==2.10.3


### PR DESCRIPTION
https://docs.djangoproject.com/en/1.9/releases/1.9/#features-removed-in-1-9