### PR TITLE
Update pypi.python.org URL to pypi.org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ Full featured redis cache backend for Django.
     :target: https://travis-ci.org/niwinz/django-redis
 
 .. image:: https://img.shields.io/pypi/v/django-redis.svg?style=flat
-    :target: https://pypi.python.org/pypi/django-redis
+    :target: https://pypi.org/project/django-redis/
 
 
 Documentation


### PR DESCRIPTION
For details on the new PyPI, see the blog post:

https://pythoninsider.blogspot.ca/2018/04/new-pypi-launched-legacy-pypi-shutting.html