### PR TITLE
Fix get method exception catching

### DIFF
--- a/django_redis/cache.py
+++ b/django_redis/cache.py
@@ -80,7 +80,7 @@ class RedisCache(BaseCache):
             return self.client.get(key, default=default, version=version,
                                    client=client)
         except ConnectionInterrupted as e:
-            if DJANGO_REDIS_IGNORE_EXCEPTIONS or self._ignore_exceptions:
+            if self._ignore_exceptions:
                 if DJANGO_REDIS_LOG_IGNORED_EXCEPTIONS:
                     logger.error(str(e))
                 return default


### PR DESCRIPTION
Example:
```
DJANGO_REDIS_IGNORE_EXCEPTIONS = True
CACHES = {
    "default": {
        "BACKEND": "django_redis.cache.RedisCache",
        "OPTIONS": {
            "IGNORE_EXCEPTIONS": False,
        }
    },
}
```
Stop redis and check:
`caches['default'].set('foo', 'bar')`
`ConnectionError: Error 61 connecting to localhost:32768. Connection refused`.
`caches['default'].get('foo')`
Exception ignored