### PR TITLE
Pin redis version to 2.10.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ flake8
 isort
 mock
 msgpack-python>=0.4.6
-redis>=2.10.0
+redis>=2.10.0,<3.0.0
 wheel
 lz4>=0.15

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
     install_requires=[
         "Django>=1.11",
-        "redis>=2.10.0",
+        "redis>=2.10.0,<3.0.0",
     ],
     zip_safe=False,
     include_package_data=True,


### PR DESCRIPTION
To avoid some trouble with Redis [3.x series](https://github.com/andymccurdy/redis-py#upgrading-from-redis-py-2x-to-30)