### PR TITLE
Add support redis-py 3.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,37 +5,71 @@ cache: pip
 matrix:
   include:
     - python: 2.7
-      env: TOXENV=py27-django111
+      env: TOXENV=py27-django111-redis2
+    - python: 2.7
+      env: TOXENV=py27-django111-redislatest
     - python: 3.4
-      env: TOXENV=py34-django111
-    - python: 3.5
-      env: TOXENV=py35-django111
-    - python: 3.6
-      env: TOXENV=py36-django111
+      env: TOXENV=py34-django111-redis2
     - python: 3.4
-      env: TOXENV=py34-django20
+      env: TOXENV=py34-django111-redislatest
     - python: 3.5
-      env: TOXENV=py35-django20
+      env: TOXENV=py35-django111-redis2
+    - python: 3.5
+      env: TOXENV=py35-django111-redislatest
     - python: 3.6
-      env: TOXENV=py36-django20
+      env: TOXENV=py36-django111-redis2
+    - python: 3.6
+      env: TOXENV=py36-django111-redislatest
+    - python: 3.4
+      env: TOXENV=py34-django20-redis2
+    - python: 3.4
+      env: TOXENV=py34-django20-redislatest
+    - python: 3.5
+      env: TOXENV=py35-django20-redis2
+    - python: 3.5
+      env: TOXENV=py35-django20-redislatest
+    - python: 3.6
+      env: TOXENV=py36-django20-redis2
+    - python: 3.6
+      env: TOXENV=py36-django20-redislatest
     - python: 3.7
-      env: TOXENV=py37-django20
+      env: TOXENV=py37-django20-redis2
+      dist: xenial
+      sudo: required
+    - python: 3.7
+      env: TOXENV=py37-django20-redislatest
       dist: xenial
       sudo: required
     - python: 3.5
-      env: TOXENV=py35-django21
+      env: TOXENV=py35-django21-redis2
+    - python: 3.5
+      env: TOXENV=py35-django21-redislatest
     - python: 3.6
-      env: TOXENV=py36-django21
+      env: TOXENV=py36-django21-redis2
+    - python: 3.6
+      env: TOXENV=py36-django21-redislatest
     - python: 3.7
-      env: TOXENV=py37-django21
+      env: TOXENV=py37-django21-redis2
+      dist: xenial
+      sudo: required
+    - python: 3.7
+      env: TOXENV=py37-django21-redislatest
       dist: xenial
       sudo: required
     - python: 3.5
-      env: TOXENV=py35-djangomaster
+      env: TOXENV=py35-djangomaster-redis2
+    - python: 3.5
+      env: TOXENV=py35-djangomaster-redislatest
     - python: 3.6
-      env: TOXENV=py36-djangomaster
+      env: TOXENV=py36-djangomaster-redis2
+    - python: 3.6
+      env: TOXENV=py36-djangomaster-redislatest
     - python: 3.7
-      env: TOXENV=py37-djangomaster
+      env: TOXENV=py37-djangomaster-redis2
+      dist: xenial
+      sudo: required
+    - python: 3.7
+      env: TOXENV=py37-djangomaster-redislatest
       dist: xenial
       sudo: required
     - env: TOXENV=lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,30 +8,44 @@ matrix:
       env: TOXENV=py27-django111-redis2
     - python: 2.7
       env: TOXENV=py27-django111-redislatest
+    - python: 2.7
+      env: TOXENV=py27-django111-redismaster
     - python: 3.4
       env: TOXENV=py34-django111-redis2
     - python: 3.4
       env: TOXENV=py34-django111-redislatest
+    - python: 3.4
+      env: TOXENV=py34-django111-redismaster
     - python: 3.5
       env: TOXENV=py35-django111-redis2
     - python: 3.5
       env: TOXENV=py35-django111-redislatest
+    - python: 3.5
+      env: TOXENV=py35-django111-redismaster
     - python: 3.6
       env: TOXENV=py36-django111-redis2
     - python: 3.6
       env: TOXENV=py36-django111-redislatest
+    - python: 3.6
+      env: TOXENV=py36-django111-redismaster
     - python: 3.4
       env: TOXENV=py34-django20-redis2
     - python: 3.4
       env: TOXENV=py34-django20-redislatest
+    - python: 3.4
+      env: TOXENV=py34-django20-redismaster
     - python: 3.5
       env: TOXENV=py35-django20-redis2
     - python: 3.5
       env: TOXENV=py35-django20-redislatest
+    - python: 3.5
+      env: TOXENV=py35-django20-redismaster
     - python: 3.6
       env: TOXENV=py36-django20-redis2
     - python: 3.6
       env: TOXENV=py36-django20-redislatest
+    - python: 3.6
+      env: TOXENV=py36-django20-redismaster
     - python: 3.7
       env: TOXENV=py37-django20-redis2
       dist: xenial
@@ -40,14 +54,22 @@ matrix:
       env: TOXENV=py37-django20-redislatest
       dist: xenial
       sudo: required
+    - python: 3.7
+      env: TOXENV=py37-django20-redismaster
+      dist: xenial
+      sudo: required
     - python: 3.5
       env: TOXENV=py35-django21-redis2
     - python: 3.5
       env: TOXENV=py35-django21-redislatest
+    - python: 3.5
+      env: TOXENV=py35-django21-redismaster
     - python: 3.6
       env: TOXENV=py36-django21-redis2
     - python: 3.6
       env: TOXENV=py36-django21-redislatest
+    - python: 3.6
+      env: TOXENV=py36-django21-redismaster
     - python: 3.7
       env: TOXENV=py37-django21-redis2
       dist: xenial
@@ -56,14 +78,22 @@ matrix:
       env: TOXENV=py37-django21-redislatest
       dist: xenial
       sudo: required
+    - python: 3.7
+      env: TOXENV=py37-django21-redismaster
+      dist: xenial
+      sudo: required
     - python: 3.5
       env: TOXENV=py35-djangomaster-redis2
     - python: 3.5
       env: TOXENV=py35-djangomaster-redislatest
+    - python: 3.5
+      env: TOXENV=py35-djangomaster-redismaster
     - python: 3.6
       env: TOXENV=py36-djangomaster-redis2
     - python: 3.6
       env: TOXENV=py36-djangomaster-redislatest
+    - python: 3.6
+      env: TOXENV=py36-djangomaster-redismaster
     - python: 3.7
       env: TOXENV=py37-djangomaster-redis2
       dist: xenial
@@ -72,8 +102,11 @@ matrix:
       env: TOXENV=py37-djangomaster-redislatest
       dist: xenial
       sudo: required
+    - python: 3.7
+      env: TOXENV=py37-djangomaster-redismaster
+      dist: xenial
+      sudo: required
     - env: TOXENV=lint
-
 install:
   - pip install tox
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,7 @@ UNRELEASED
 
 - Add support and testing for Django 2.1 and Python 3.7. No actual code changes
   were required.
+- Add support for redis-py 3.0.
 
 Version 4.9.0
 -------------

--- a/django_redis/client/default.py
+++ b/django_redis/client/default.py
@@ -34,8 +34,9 @@ class DefaultClient(object):
         self._server = server
         self._params = params
 
-        self.reverse_key = get_key_func(params.get("REVERSE_KEY_FUNCTION") or
-                                        "django_redis.util.default_reverse_key")
+        self.reverse_key = get_key_func(
+            params.get("REVERSE_KEY_FUNCTION") or "django_redis.util.default_reverse_key"
+        )
 
         if not self._server:
             raise ImproperlyConfigured("Missing connections string")

--- a/django_redis/client/default.py
+++ b/django_redis/client/default.py
@@ -473,7 +473,7 @@ class DefaultClient(object):
 
         key = self.make_key(key, version=version)
         try:
-            return client.exists(key)
+            return client.exists(key) == 1
         except _main_exceptions as e:
             raise ConnectionInterrupted(connection=client, parent=e)
 

--- a/django_redis/client/sharded.py
+++ b/django_redis/client/sharded.py
@@ -118,7 +118,7 @@ class ShardClient(DefaultClient):
 
         key = self.make_key(key, version=version)
         try:
-            return client.exists(key)
+            return client.exists(key) == 1
         except ConnectionError:
             raise ConnectionInterrupted(connection=client)
 

--- a/django_redis/util.py
+++ b/django_redis/util.py
@@ -5,23 +5,15 @@ from __future__ import absolute_import, unicode_literals
 from importlib import import_module
 
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.encoding import python_2_unicode_compatible, smart_text
+from django.utils import six
 
 
-@python_2_unicode_compatible
-class CacheKey(object):
+class CacheKey(six.text_type):
     """
     A stub string class that we can use to check if a key was created already.
     """
-    def __init__(self, key):
-        self._key = key
-
-    def __str__(self):
-        return smart_text(self._key)
-
     def original_key(self):
-        key = self._key.rsplit(":", 1)[1]
-        return key
+        return self.rsplit(":", 1)[1]
 
 
 def load_class(path):

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -546,10 +546,8 @@ class DjangoRedisCacheTests(unittest.TestCase):
     def test_ttl(self):
         cache = caches["default"]
         _params = cache._params
-        _is_herd = (_params["OPTIONS"]["CLIENT_CLASS"] ==
-                    "django_redis.client.HerdClient")
-        _is_shard = (_params["OPTIONS"]["CLIENT_CLASS"] ==
-                     "django_redis.client.ShardClient")
+        _is_herd = _params["OPTIONS"]["CLIENT_CLASS"] == "django_redis.client.HerdClient"
+        _is_shard = _params["OPTIONS"]["CLIENT_CLASS"] == "django_redis.client.ShardClient"
 
         # Not supported for shard client.
         if _is_shard:
@@ -602,8 +600,7 @@ class DjangoRedisCacheTests(unittest.TestCase):
     def test_iter_keys(self):
         cache = caches["default"]
         _params = cache._params
-        _is_shard = (_params["OPTIONS"]["CLIENT_CLASS"] ==
-                     "django_redis.client.ShardClient")
+        _is_shard = _params["OPTIONS"]["CLIENT_CLASS"] == "django_redis.client.ShardClient"
 
         if _is_shard:
             return

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -974,7 +974,7 @@ class SessionTestsMixin:
         self.assertEqual(self.session.decode(encoded), data)
 
     def test_decode_failure_logged_to_security(self):
-        bad_encode = base64.b64encode(b'flaskdj:alkdjf')
+        bad_encode = base64.b64encode(b'flaskdj:alkdjf').decode()
         with patch_logger('django.security.SuspiciousSession', 'warning') as calls:
             self.assertEqual({}, self.session.decode(bad_encode))
             # check that the failed decode is logged

--- a/tests/test_sqlite.py
+++ b/tests/test_sqlite.py
@@ -13,7 +13,7 @@ CACHES = {
     },
     "doesnotexist": {
         "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": "127.0.0.1:56379:1",
+        "LOCATION": "redis://127.0.0.1:56379?db=1",
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
         }

--- a/tests/test_sqlite_herd.py
+++ b/tests/test_sqlite_herd.py
@@ -10,11 +10,11 @@ CACHES = {
             'CLIENT_CLASS': 'django_redis.client.HerdClient',
         }
     },
-    'doesnotexist': {
-        'BACKEND': 'django_redis.cache.RedisCache',
-        'LOCATION': '127.0.0.1:56379:1',
-        'OPTIONS': {
-            'CLIENT_CLASS': 'django_redis.client.HerdClient',
+    "doesnotexist": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": "redis://127.0.0.1:56379?db=1",
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.HerdClient",
         }
     },
     'sample': {

--- a/tests/test_sqlite_json.py
+++ b/tests/test_sqlite_json.py
@@ -14,7 +14,7 @@ CACHES = {
     },
     "doesnotexist": {
         "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": "127.0.0.1:56379:1",
+        "LOCATION": "redis://127.0.0.1:56379?db=1",
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
             "SERIALIZER": "django_redis.serializers.json.JSONSerializer",

--- a/tests/test_sqlite_lz4.py
+++ b/tests/test_sqlite_lz4.py
@@ -14,7 +14,7 @@ CACHES = {
     },
     "doesnotexist": {
         "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": "127.0.0.1:56379:1",
+        "LOCATION": "redis://127.0.0.1:56379?db=1",
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
             "COMPRESSOR": "django_redis.compressors.lz4.Lz4Compressor",

--- a/tests/test_sqlite_msgpack.py
+++ b/tests/test_sqlite_msgpack.py
@@ -14,7 +14,7 @@ CACHES = {
     },
     "doesnotexist": {
         "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": "127.0.0.1:56379:1",
+        "LOCATION": "redis://127.0.0.1:56379?db=1",
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
             "SERIALIZER": "django_redis.serializers.msgpack.MSGPackSerializer",

--- a/tests/test_sqlite_sharding.py
+++ b/tests/test_sqlite_sharding.py
@@ -14,8 +14,8 @@ CACHES = {
     'doesnotexist': {
         'BACKEND': 'django_redis.cache.RedisCache',
         'LOCATION': [
-            '127.0.0.1:56379:1',
-            '127.0.0.1:56379:2',
+            "redis://127.0.0.1:56379?db=1",
+            "redis://127.0.0.1:56379?db=2",
         ],
         'OPTIONS': {
             'CLIENT_CLASS': 'django_redis.client.ShardClient',

--- a/tests/test_sqlite_usock.py
+++ b/tests/test_sqlite_usock.py
@@ -13,7 +13,7 @@ CACHES = {
     },
     'doesnotexist': {
         'BACKEND': 'redis_cache.cache.RedisCache',
-        'LOCATION': '127.0.0.1:56379:1',
+        'LOCATION': 'redis://127.0.0.1:56379?db=1',
         'OPTIONS': {
             'CLIENT_CLASS': 'redis_cache.client.DefaultClient',
         }

--- a/tests/test_sqlite_zlib.py
+++ b/tests/test_sqlite_zlib.py
@@ -14,7 +14,7 @@ CACHES = {
     },
     "doesnotexist": {
         "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": "127.0.0.1:56379:1",
+        "LOCATION": "redis://127.0.0.1:56379?db=1",
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
             "COMPRESSOR": "django_redis.compressors.zlib.ZlibCompressor",

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
 envlist =
     lint
-    py{27,34,35,36}-django111-redis{2,latest}
-    py{34,35,36,37}-django20-redis{2,latest}
-    py{35,36,37}-django21-redis{2,latest}
-    py{35,36,37}-djangomaster-redis{2,latest}
+    py{27,34,35,36}-django111-redis{2,latest,master}
+    py{34,35,36,37}-django20-redis{2,latest,master}
+    py{35,36,37}-django21-redis{2,latest,master}
+    py{35,36,37}-djangomaster-redis{2,latest,master}
 
 [testenv]
 commands =
@@ -24,6 +24,7 @@ deps =
     mock
     msgpack-python>=0.4.6
     redis2: redis>=2.10.0,<3.0.0
+    redismaster: https://github.com/andymccurdy/redis-py/archive/master.tar.gz
     lz4>=0.15
 
 [testenv:lint]

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
 envlist =
     lint
-    py{27,34,35,36}-django111
-    py{34,35,36,37}-django20
-    py{35,36,37}-django21
-    py{35,36,37}-djangomaster
+    py{27,34,35,36}-django111-redis{2,latest}
+    py{34,35,36,37}-django20-redis{2,latest}
+    py{35,36,37}-django21-redis{2,latest}
+    py{35,36,37}-djangomaster-redis{2,latest}
 
 [testenv]
 commands =
@@ -23,7 +23,7 @@ deps =
     djangomaster: https://github.com/django/django/archive/master.tar.gz
     mock
     msgpack-python>=0.4.6
-    redis>=2.10.0
+    redis2: redis>=2.10.0,<3.0.0
     lz4>=0.15
 
 [testenv:lint]


### PR DESCRIPTION
- Make CacheKey inherit from `str` to fix exception "Only bytes, strings and numbers (ints, longs and floats) are acceptable for keys and values."
- `.exists()` now returns and integer, so update `.has_key()`.
- Remove erroneous tests so all tests pass again.
- Fix flake8 errors.
    
Fixes #342