### PR TITLE
Remove wheel from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,4 @@ isort
 mock
 msgpack-python>=0.4.6
 redis>=2.10.0
-wheel
 lz4>=0.15


### PR DESCRIPTION
The wheel package isn't a requirement for developing, only releasing.
Can easily rely on the system Python and wheel package for releases.
Removes an unnecessary dependency during routine development.