### PR TITLE
Replace load_class with Django's import_string

### DIFF
--- a/django_redis/cache.py
+++ b/django_redis/cache.py
@@ -3,9 +3,9 @@ import logging
 
 from django.conf import settings
 from django.core.cache.backends.base import BaseCache
+from django.utils.module_loading import import_string
 
 from .exceptions import ConnectionInterrupted
-from .util import load_class
 
 DJANGO_REDIS_IGNORE_EXCEPTIONS = getattr(settings, "DJANGO_REDIS_IGNORE_EXCEPTIONS", False)
 DJANGO_REDIS_LOG_IGNORED_EXCEPTIONS = getattr(settings, "DJANGO_REDIS_LOG_IGNORED_EXCEPTIONS", False)
@@ -48,7 +48,7 @@ class RedisCache(BaseCache):
 
         options = params.get("OPTIONS", {})
         self._client_cls = options.get("CLIENT_CLASS", "django_redis.client.DefaultClient")
-        self._client_cls = load_class(self._client_cls)
+        self._client_cls = import_string(self._client_cls)
         self._client = None
 
         self._ignore_exceptions = options.get("IGNORE_EXCEPTIONS", DJANGO_REDIS_IGNORE_EXCEPTIONS)

--- a/django_redis/client/default.py
+++ b/django_redis/client/default.py
@@ -12,11 +12,12 @@ from django.core.cache.backends.base import DEFAULT_TIMEOUT, get_key_func
 from django.core.exceptions import ImproperlyConfigured
 from django.utils import six
 from django.utils.encoding import smart_text
+from django.utils.module_loading import import_string
 from redis.exceptions import ConnectionError, ResponseError, TimeoutError
 
 from .. import pool
 from ..exceptions import CompressorError, ConnectionInterrupted
-from ..util import CacheKey, load_class
+from ..util import CacheKey
 
 _main_exceptions = (TimeoutError, ResponseError, ConnectionError, socket.timeout)
 
@@ -49,10 +50,10 @@ class DefaultClient(object):
         self._slave_read_only = self._options.get('SLAVE_READ_ONLY', True)
 
         serializer_path = self._options.get("SERIALIZER", "django_redis.serializers.pickle.PickleSerializer")
-        serializer_cls = load_class(serializer_path)
+        serializer_cls = import_string(serializer_path)
 
         compressor_path = self._options.get("COMPRESSOR", "django_redis.compressors.identity.IdentityCompressor")
-        compressor_cls = load_class(compressor_path)
+        compressor_cls = import_string(compressor_path)
 
         self._serializer = serializer_cls(options=self._options)
         self._compressor = compressor_cls(options=self._options)

--- a/django_redis/pool.py
+++ b/django_redis/pool.py
@@ -1,7 +1,6 @@
 from django.conf import settings
+from django.utils.module_loading import import_string
 from redis.connection import DefaultParser
-
-from . import util
 
 
 class ConnectionFactory(object):
@@ -17,12 +16,12 @@ class ConnectionFactory(object):
     def __init__(self, options):
         pool_cls_path = options.get("CONNECTION_POOL_CLASS",
                                     "redis.connection.ConnectionPool")
-        self.pool_cls = util.load_class(pool_cls_path)
+        self.pool_cls = import_string(pool_cls_path)
         self.pool_cls_kwargs = options.get("CONNECTION_POOL_KWARGS", {})
 
         redis_client_cls_path = options.get("REDIS_CLIENT_CLASS",
                                             "redis.client.StrictRedis")
-        self.redis_client_cls = util.load_class(redis_client_cls_path)
+        self.redis_client_cls = import_string(redis_client_cls_path)
         self.redis_client_cls_kwargs = options.get("REDIS_CLIENT_KWARGS", {})
 
         self.options = options
@@ -80,7 +79,7 @@ class ConnectionFactory(object):
         cls = self.options.get("PARSER_CLASS", None)
         if cls is None:
             return DefaultParser
-        return util.load_class(cls)
+        return import_string(cls)
 
     def get_or_create_connection_pool(self, params):
         """
@@ -119,5 +118,5 @@ def get_connection_factory(path=None, options=None):
         path = getattr(settings, "DJANGO_REDIS_CONNECTION_FACTORY",
                        "django_redis.pool.ConnectionFactory")
 
-    cls = util.load_class(path)
+    cls = import_string(path)
     return cls(options or {})

--- a/django_redis/util.py
+++ b/django_redis/util.py
@@ -2,9 +2,6 @@
 
 from __future__ import absolute_import, unicode_literals
 
-from importlib import import_module
-
-from django.core.exceptions import ImproperlyConfigured
 from django.utils import six
 
 
@@ -14,26 +11,6 @@ class CacheKey(six.text_type):
     """
     def original_key(self):
         return self.rsplit(":", 1)[1]
-
-
-def load_class(path):
-    """
-    Loads class from path.
-    """
-
-    mod_name, klass_name = path.rsplit('.', 1)
-
-    try:
-        mod = import_module(mod_name)
-    except AttributeError as e:
-        raise ImproperlyConfigured('Error importing {0}: "{1}"'.format(mod_name, e))
-
-    try:
-        klass = getattr(mod, klass_name)
-    except AttributeError:
-        raise ImproperlyConfigured('Module "{0}" does not define a "{1}" class'.format(mod_name, klass_name))
-
-    return klass
 
 
 def default_reverse_key(key):


### PR DESCRIPTION
The local function `load_class()` duplicates Django's `import_string()`. Simply reuse it instead of re-implementing it.

https://docs.djangoproject.com/en/2.1/ref/utils/#module-django.utils.module_loading