### PR TITLE
Use 'dist: xenial' in Travis to simplify configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 sudo: false
 language: python
 cache: pip
@@ -48,16 +49,10 @@ matrix:
       env: TOXENV=py36-django20-redismaster
     - python: 3.7
       env: TOXENV=py37-django20-redis2
-      dist: xenial
-      sudo: required
     - python: 3.7
       env: TOXENV=py37-django20-redislatest
-      dist: xenial
-      sudo: required
     - python: 3.7
       env: TOXENV=py37-django20-redismaster
-      dist: xenial
-      sudo: required
     - python: 3.5
       env: TOXENV=py35-django21-redis2
     - python: 3.5
@@ -72,16 +67,10 @@ matrix:
       env: TOXENV=py36-django21-redismaster
     - python: 3.7
       env: TOXENV=py37-django21-redis2
-      dist: xenial
-      sudo: required
     - python: 3.7
       env: TOXENV=py37-django21-redislatest
-      dist: xenial
-      sudo: required
     - python: 3.7
       env: TOXENV=py37-django21-redismaster
-      dist: xenial
-      sudo: required
     - python: 3.5
       env: TOXENV=py35-djangomaster-redis2
     - python: 3.5
@@ -96,16 +85,10 @@ matrix:
       env: TOXENV=py36-djangomaster-redismaster
     - python: 3.7
       env: TOXENV=py37-djangomaster-redis2
-      dist: xenial
-      sudo: required
     - python: 3.7
       env: TOXENV=py37-djangomaster-redislatest
-      dist: xenial
-      sudo: required
     - python: 3.7
       env: TOXENV=py37-djangomaster-redismaster
-      dist: xenial
-      sudo: required
     - env: TOXENV=lint
 install:
   - pip install tox


### PR DESCRIPTION
Allows using Python version 3.7 without sudo declarations.

Travis officially added support for Xenial on 2018-11-08.

https://blog.travis-ci.com/2018-11-08-xenial-release