### PR TITLE
Add Django 2.2a1 to the test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,6 +72,24 @@ matrix:
     - python: 3.7
       env: TOXENV=py37-django21-redismaster
     - python: 3.5
+      env: TOXENV=py35-django22-redis2
+    - python: 3.5
+      env: TOXENV=py35-django22-redislatest
+    - python: 3.5
+      env: TOXENV=py35-django22-redismaster
+    - python: 3.6
+      env: TOXENV=py36-django22-redis2
+    - python: 3.6
+      env: TOXENV=py36-django22-redislatest
+    - python: 3.6
+      env: TOXENV=py36-django22-redismaster
+    - python: 3.7
+      env: TOXENV=py37-django22-redis2
+    - python: 3.7
+      env: TOXENV=py37-django22-redislatest
+    - python: 3.7
+      env: TOXENV=py37-django22-redismaster
+    - python: 3.5
       env: TOXENV=py35-djangomaster-redis2
     - python: 3.5
       env: TOXENV=py35-djangomaster-redislatest

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         "Framework :: Django :: 1.11",
         "Framework :: Django :: 2.0",
         "Framework :: Django :: 2.1",
+        "Framework :: Django :: 2.2",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
     py{27,34,35,36}-django111-redis{2,latest,master}
     py{34,35,36,37}-django20-redis{2,latest,master}
     py{35,36,37}-django21-redis{2,latest,master}
+    py{35,36,37}-django22-redis{2,latest,master}
     py{35,36,37}-djangomaster-redis{2,latest,master}
 
 [testenv]
@@ -20,6 +21,7 @@ deps =
     django111: Django>=1.11,<2.0
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
+    django22: Django>=2.2a1,<2.3
     djangomaster: https://github.com/django/django/archive/master.tar.gz
     mock
     msgpack-python>=0.4.6


### PR DESCRIPTION
Django 2.2 alpha 1 was released on January 17, 2019.

https://www.djangoproject.com/weblog/2019/jan/17/django-22-alpha-1/