### PR TITLE
tests/: Fix URL syntax

### DIFF
--- a/tests/test_sqlite.py
+++ b/tests/test_sqlite.py
@@ -20,7 +20,7 @@ CACHES = {
     },
     "sample": {
         "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": "127.0.0.1:6379:1,127.0.0.1:6379:1",
+        "LOCATION": "redis://127.0.0.1:6379:1,redis://127.0.0.1:6379:1",
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
         }

--- a/tests/test_sqlite_herd.py
+++ b/tests/test_sqlite_herd.py
@@ -4,7 +4,7 @@ CACHES = {
     'default': {
         'BACKEND': 'django_redis.cache.RedisCache',
         'LOCATION': [
-            '127.0.0.1:6379:5',
+            'redis://127.0.0.1:6379?db=5',
         ],
         'OPTIONS': {
             'CLIENT_CLASS': 'django_redis.client.HerdClient',
@@ -19,7 +19,7 @@ CACHES = {
     },
     'sample': {
         'BACKEND': 'django_redis.cache.RedisCache',
-        'LOCATION': '127.0.0.1:6379:1,127.0.0.1:6379:1',
+        'LOCATION': 'redis://127.0.0.1:6379?db=1,redis://127.0.0.1:6379?db=1',
         'OPTIONS': {
             'CLIENT_CLASS': 'django_redis.client.HerdClient',
         }

--- a/tests/test_sqlite_json.py
+++ b/tests/test_sqlite_json.py
@@ -22,7 +22,7 @@ CACHES = {
     },
     "sample": {
         "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": "127.0.0.1:6379:1,127.0.0.1:6379:1",
+        "LOCATION": "redis://127.0.0.1:6379?db=1,redis://127.0.0.1:6379?db=1",
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
             "SERIALIZER": "django_redis.serializers.json.JSONSerializer",

--- a/tests/test_sqlite_lz4.py
+++ b/tests/test_sqlite_lz4.py
@@ -22,7 +22,7 @@ CACHES = {
     },
     "sample": {
         "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": "127.0.0.1:6379:1,127.0.0.1:6379:1",
+        "LOCATION": "127.0.0.1:6379?db=1,127.0.0.1:6379?db=1",
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
             "COMPRESSOR": "django_redis.compressors.lz4.Lz4Compressor",

--- a/tests/test_sqlite_msgpack.py
+++ b/tests/test_sqlite_msgpack.py
@@ -22,7 +22,7 @@ CACHES = {
     },
     "sample": {
         "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": "127.0.0.1:6379:1,127.0.0.1:6379:1",
+        "LOCATION": "redis://127.0.0.1:6379?db=1,redis://127.0.0.1:6379?db=1",
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
             "SERIALIZER": "django_redis.serializers.msgpack.MSGPackSerializer",

--- a/tests/test_sqlite_sharding.py
+++ b/tests/test_sqlite_sharding.py
@@ -4,8 +4,8 @@ CACHES = {
     'default': {
         'BACKEND': 'django_redis.cache.RedisCache',
         'LOCATION': [
-            '127.0.0.1:6379:1',
-            '127.0.0.1:6379:2',
+            'redis://127.0.0.1:6379?db=1',
+            'redis://127.0.0.1:6379?db=2',
         ],
         'OPTIONS': {
             'CLIENT_CLASS': 'django_redis.client.ShardClient',
@@ -23,7 +23,7 @@ CACHES = {
     },
     'sample': {
         'BACKEND': 'django_redis.cache.RedisCache',
-        'LOCATION': '127.0.0.1:6379:1,127.0.0.1:6379:1',
+        'LOCATION': 'redis://127.0.0.1:6379?db=1,redis://127.0.0.1:6379?db=1',
         'OPTIONS': {
             'CLIENT_CLASS': 'django_redis.client.ShardClient',
         }

--- a/tests/test_sqlite_usock.py
+++ b/tests/test_sqlite_usock.py
@@ -20,7 +20,7 @@ CACHES = {
     },
     'sample': {
         'BACKEND': 'redis_cache.cache.RedisCache',
-        'LOCATION': '127.0.0.1:6379:1,127.0.0.1:6379:1',
+        'LOCATION': 'redis://127.0.0.1:6379?db=1,redis://127.0.0.1:6379?db=1',
         'OPTIONS': {
             'CLIENT_CLASS': 'redis_cache.client.DefaultClient',
         }

--- a/tests/test_sqlite_zlib.py
+++ b/tests/test_sqlite_zlib.py
@@ -22,7 +22,7 @@ CACHES = {
     },
     "sample": {
         "BACKEND": "django_redis.cache.RedisCache",
-        "LOCATION": "127.0.0.1:6379:1,127.0.0.1:6379:1",
+        "LOCATION": "redis://127.0.0.1:6379?db=1,redis://127.0.0.1:6379?db=1",
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
             "COMPRESSOR": "django_redis.compressors.zlib.ZlibCompressor",


### PR DESCRIPTION
python package redis 3.1.0 added exceptions for invalid URLs,
which tripped some of the URLs in the test suite.

Closes https://github.com/niwinz/django-redis/issues/366