### PR TITLE
Test against for Django 2.2 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,10 +91,6 @@ matrix:
       env: TOXENV=py37-django22-redismaster
     - python: 3.5
       env: TOXENV=py35-djangomaster-redis2
-    - python: 3.5
-      env: TOXENV=py35-djangomaster-redislatest
-    - python: 3.5
-      env: TOXENV=py35-djangomaster-redismaster
     - python: 3.6
       env: TOXENV=py36-djangomaster-redis2
     - python: 3.6

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist =
     py{34,35,36,37}-django20-redis{2,latest,master}
     py{35,36,37}-django21-redis{2,latest,master}
     py{35,36,37}-django22-redis{2,latest,master}
-    py{35,36,37}-djangomaster-redis{2,latest,master}
+    py{36,37}-djangomaster-redis{2,latest,master}
 
 [testenv]
 commands =
@@ -21,7 +21,7 @@ deps =
     django111: Django>=1.11,<2.0
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
-    django22: Django>=2.2a1,<2.3
+    django22: Django>=2.2,<2.3
     djangomaster: https://github.com/django/django/archive/master.tar.gz
     mock
     msgpack-python>=0.4.6


### PR DESCRIPTION
Announcement:
https://www.djangoproject.com/weblog/2019/apr/01/django-22-released/

Release notes:
https://docs.djangoproject.com/en/2.2/releases/2.2/

Django master dropped support for Python 3.5.