### PR TITLE
Fix prefix escaping at ShardClient.keys function

### DIFF
--- a/django_redis/client/sharded.py
+++ b/django_redis/client/sharded.py
@@ -220,7 +220,7 @@ class ShardClient(DefaultClient):
         raise NotImplementedError("iter_keys not supported on sharded client")
 
     def keys(self, search, version=None):
-        pattern = self.make_key(search, version=version)
+        pattern = self.make_pattern(search, version=version)
         keys = []
         try:
             for server, connection in self._serverdict.items():

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -84,9 +84,6 @@ class DjangoRedisCacheTestEscapePrefix(unittest.TestCase):
         self.assertEqual(list(self.cache.iter_keys('*')), ['a'])
 
     def test_keys(self):
-        if isinstance(self.cache.client, ShardClient):
-            self.skipTest("ShardClient doesn't support iter_keys")
-
         self.cache.set('a', '1')
         self.other.set('b', '2')
         keys = self.cache.keys('*')


### PR DESCRIPTION
Hello @niwinz,

This PR fixes #367 and compatibility with Django's `master` branch.

Currently, the `keys` function uses the `make_key` function which doesn't escape the prefix. In case the default `*` prefix is used and some other client uses the same redis db with non-default prefix, it misleads to fetching of prefixed keys of the other client.
In order to fix the issue, we have to use the `make_pattern` function instead of the `make_key` function.

Best regards!