### PR TITLE
Forward thread_local param to redis client

### DIFF
--- a/django_redis/client/default.py
+++ b/django_redis/client/default.py
@@ -252,13 +252,18 @@ class DefaultClient:
         sleep=0.1,
         blocking_timeout=None,
         client=None,
+        thread_local=True,
     ):
         if client is None:
             client = self.get_client(write=True)
 
         key = self.make_key(key, version=version)
         return client.lock(
-            key, timeout=timeout, sleep=sleep, blocking_timeout=blocking_timeout
+            key,
+            timeout=timeout,
+            sleep=sleep,
+            blocking_timeout=blocking_timeout,
+            thread_local=thread_local,
         )
 
     def delete(self, key, version=None, prefix=None, client=None):

--- a/django_redis/client/sharded.py
+++ b/django_redis/client/sharded.py
@@ -159,6 +159,7 @@ class ShardClient(DefaultClient):
         sleep=0.1,
         blocking_timeout=None,
         client=None,
+        thread_local=True,
     ):
 
         if client is None:
@@ -172,6 +173,7 @@ class ShardClient(DefaultClient):
             sleep=sleep,
             client=client,
             blocking_timeout=blocking_timeout,
+            thread_local=thread_local,
         )
 
     def delete_many(self, keys, version=None):


### PR DESCRIPTION
I need to forward an acquired lock to a worker thread that should release it. From redis-py docs:

        In some use cases it's necessary to disable thread local storage. For
        example, if you have code where one thread acquires a lock and passes
        that lock instance to a worker thread to release later. If thread
        local storage isn't disabled in this case, the worker thread won't see
        the token set by the thread that acquired the lock. Our assumption
        is that these cases aren't common and as such default to using
        thread local storage.