### PR TITLE
Fix add() return True/False

### DIFF
--- a/django_redis/client/default.py
+++ b/django_redis/client/default.py
@@ -136,7 +136,7 @@ class DefaultClient:
                             # than to set it and than expire in a pipeline
                             return self.delete(key, client=client, version=version)
 
-                return client.set(nkey, nvalue, nx=nx, px=timeout, xx=xx)
+                return bool(client.set(nkey, nvalue, nx=nx, px=timeout, xx=xx))
             except _main_exceptions as e:
                 if not original_client and not self._slave_read_only and len(tried) < len(self._server):
                     tried.append(index)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -283,10 +283,14 @@ class DjangoRedisCacheTests(unittest.TestCase):
 
     def test_set_add(self):
         self.cache.set("add_key", "Initial value")
-        self.cache.add("add_key", "New value")
-        res = cache.get("add_key")
+        res = self.cache.add("add_key", "New value")
+        self.assertIs(res, False)
 
+        res = cache.get("add_key")
         self.assertEqual(res, "Initial value")
+
+        res = self.cache.add("other_key", "New value")
+        self.assertIs(res, True)
 
     def test_get_many(self):
         self.cache.set("a", 1)


### PR DESCRIPTION
Now follows the Django spec

https://docs.djangoproject.com/en/2.2/topics/cache/#django.core.caches.cache.add

> If you need to know whether add() stored a value in the cache, you can
> check the return value. It will return True if the value was stored,
> False otherwise.

Thanks Kris Pritchard for the original patch.

Thanks Terence Honles for the suggested improvement.

Fixes #340