### PR TITLE
Fix .touch()

### DIFF
--- a/django_redis/cache.py
+++ b/django_redis/cache.py
@@ -160,5 +160,5 @@ class RedisCache(BaseCache):
         self.client.close(**kwargs)
 
     @omit_exception
-    def touch(self, key, timeout=None, version=None):
-        return self.client.touch(key, timeout=timeout, version=version)
+    def touch(self, *args, **kwargs):
+        return self.client.touch(*args, **kwargs)

--- a/django_redis/client/default.py
+++ b/django_redis/client/default.py
@@ -576,9 +576,16 @@ class DefaultClient:
         Sets a new expiration for a key.
         """
 
+        if timeout is DEFAULT_TIMEOUT:
+            timeout = self._backend.default_timeout
+
         if client is None:
             client = self.get_client(write=True)
 
         key = self.make_key(key, version=version)
-
-        return client.expire(key, timeout)
+        if timeout is None:
+            return bool(client.persist(key))
+        else:
+            # Convert to milliseconds
+            timeout = int(timeout * 1000)
+            return bool(client.pexpire(key, timeout))

--- a/django_redis/client/herd.py
+++ b/django_redis/client/herd.py
@@ -154,3 +154,14 @@ class HerdClient(DefaultClient):
 
     def decr(self, *args, **kwargs):
         raise NotImplementedError()
+
+    def touch(self, key, timeout=DEFAULT_TIMEOUT, version=None, client=None):
+        if client is None:
+            client = self.get_client(write=True)
+
+        value = self.get(key, version=version, client=client)
+        if value is None:
+            return False
+
+        self.set(key, value, timeout=timeout, version=version, client=client)
+        return True

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -639,7 +639,26 @@ class DjangoRedisCacheTests(unittest.TestCase):
         self.assertIsNone(res)
 
     def test_touch_missed_key(self):
-        self.assertIs(self.cache.touch("test_key", -1), False)
+        self.assertIs(self.cache.touch("test_key_does_not_exist", 1), False)
+
+    def test_touch_forever(self):
+        self.cache.set("test_key", "foo", timeout=1)
+        result = self.cache.touch("test_key", None)
+        self.assertIs(result, True)
+        self.assertIsNone(self.cache.ttl("test_key"))
+        time.sleep(2)
+        self.assertEqual(self.cache.get("test_key"), "foo")
+
+    def test_touch_forever_nonexistent(self):
+        result = self.cache.touch("test_key_does_not_exist", None)
+        self.assertIs(result, False)
+
+    def test_touch_default_timeout(self):
+        self.cache.set("test_key", "foo", timeout=1)
+        result = self.cache.touch("test_key")
+        self.assertIs(result, True)
+        time.sleep(2)
+        self.assertEqual(self.cache.get("test_key"), "foo")
 
 
 class DjangoOmitExceptionsTests(unittest.TestCase):


### PR DESCRIPTION
- Should use the backend default timeout, not always default to None.
- Should accept a value of None to cache the value forever.