### PR TITLE
Compare against DEFAULT_TIMEOUT using object identity

### DIFF
--- a/django_redis/client/default.py
+++ b/django_redis/client/default.py
@@ -110,7 +110,7 @@ class DefaultClient:
         nkey = self.make_key(key, version=version)
         nvalue = self.encode(value)
 
-        if timeout == DEFAULT_TIMEOUT:
+        if timeout is DEFAULT_TIMEOUT:
             timeout = self._backend.default_timeout
 
         original_client = client

--- a/django_redis/client/herd.py
+++ b/django_redis/client/herd.py
@@ -61,7 +61,7 @@ class HerdClient(DefaultClient):
     def set(self, key, value, timeout=DEFAULT_TIMEOUT, version=None,
             client=None, nx=False, xx=False):
 
-        if timeout == DEFAULT_TIMEOUT:
+        if timeout is DEFAULT_TIMEOUT:
             timeout = self._backend.default_timeout
 
         if timeout is None or timeout <= 0:


### PR DESCRIPTION
DEFAULT_TIMEOUT is an opaque singleton.