### PR TITLE
Fix msgpack deprecation warning:

### DIFF
--- a/django_redis/serializers/msgpack.py
+++ b/django_redis/serializers/msgpack.py
@@ -8,4 +8,4 @@ class MSGPackSerializer(BaseSerializer):
         return msgpack.dumps(value)
 
     def loads(self, value):
-        return msgpack.loads(value, encoding="utf-8")
+        return msgpack.loads(value, raw=False)


### PR DESCRIPTION
    DeprecationWarning: encoding is deprecated, Use raw=False instead.