### PR TITLE
Fix DefaultClient.set method overriding empty Pipeline

### DIFF
--- a/django_redis/client/default.py
+++ b/django_redis/client/default.py
@@ -132,7 +132,7 @@ class DefaultClient:
         tried = []
         while True:
             try:
-                if not client:
+                if client is None:
                     client, index = self.get_client(
                         write=True, tried=tried, show_index=True
                     )

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -317,6 +317,9 @@ class DjangoRedisCacheTests(unittest.TestCase):
         self.assertEqual(res, {"a": 1, "b": 2, "c": 3})
 
     def test_set_call_empty_pipeline(self):
+        if isinstance(self.cache.client, ShardClient):
+            self.skipTest("ShardClient doesn't support get_client")
+
         pipeline = self.cache.client.get_client(write=True).pipeline()
         key = "key"
         value = "value"

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -322,7 +322,9 @@ class DjangoRedisCacheTests(unittest.TestCase):
         value = "value"
 
         with patch.object(pipeline, "set") as mocked_set:
-            self.cache.set(key, value, client=pipeline, )
+            self.cache.set(
+                key, value, client=pipeline,
+            )
 
         mocked_set.assert_called_once_with(
             self.cache.client.make_key(key, version=None),

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -316,6 +316,22 @@ class DjangoRedisCacheTests(unittest.TestCase):
         res = self.cache.get_many(["a", "b", "c"])
         self.assertEqual(res, {"a": 1, "b": 2, "c": 3})
 
+    def test_set_call_empty_pipeline(self):
+        pipeline = self.cache.client.get_client(write=True).pipeline()
+        key = "key"
+        value = "value"
+
+        with patch.object(pipeline, "set") as mocked_set:
+            self.cache.set(key, value, client=pipeline, )
+
+        mocked_set.assert_called_once_with(
+            self.cache.client.make_key(key, version=None),
+            self.cache.client.encode(value),
+            nx=False,
+            px=self.cache.client._backend.default_timeout * 1000,
+            xx=False,
+        )
+
     def test_delete(self):
         self.cache.set_many({"a": 1, "b": 2, "c": 3})
         res = self.cache.delete("a")

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -335,7 +335,7 @@ class DjangoRedisCacheTests(unittest.TestCase):
             herd_pack_value = self.cache.client._pack(value, default_timeout,)
             mocked_set.assert_called_once_with(
                 self.cache.client.make_key(key, version=None),
-                herd_pack_value,
+                self.cache.client.encode(herd_pack_value),
                 nx=False,
                 px=herd_timeout,
                 xx=False,

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -332,10 +332,7 @@ class DjangoRedisCacheTests(unittest.TestCase):
         if isinstance(self.cache.client, herd.HerdClient):
             default_timeout = self.cache.client._backend.default_timeout
             herd_timeout = (default_timeout + herd.CACHE_HERD_TIMEOUT) * 1000
-            herd_pack_value = self.cache.client._pack(
-                value,
-                default_timeout,
-            )
+            herd_pack_value = self.cache.client._pack(value, default_timeout,)
             mocked_set.assert_called_once_with(
                 self.cache.client.make_key(key, version=None),
                 herd_pack_value,


### PR DESCRIPTION
Issue:

`if not client` is always `True` if `client` is an empty Pipeline, so `set_many` operations are always executed one by one because `client` is overrode by `self.get_client`. 

Fix:

Change if condition to `if client is None`

Notes:

* Test for this has been included